### PR TITLE
test(escrow): add negative and auth tests for cancel_job

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -954,4 +954,58 @@ mod test {
         let (_, client, _, _, _, native_token) = setup();
         assert_eq!(client.get_native_token(), native_token);
     }
+
+    // ── cancel_job negative / auth tests (issue #19) ─────────────────────────
+
+    /// A stranger (neither the job's client nor any authorized party) must not
+    /// be able to cancel an Open job. The contract checks ownership AFTER the
+    /// status check, so an Open job with a wrong caller should panic with
+    /// Error::Unauthorized (contract error code #2).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn cancel_job_unauthorized_caller_panics() {
+        let (env, client, _, user, _, native_token) = setup();
+
+        // Post an Open job as the legitimate client
+        let job_id = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+
+        // A completely unrelated address attempts to cancel — must be rejected
+        let stranger = Address::generate(&env);
+        client.cancel_job(&stranger, &job_id);
+    }
+
+    /// cancel_job must reject a job that is already InProgress.
+    /// Only Open jobs may be cancelled by the client; any other status
+    /// triggers Error::InvalidStatus (contract error code #3).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn cancel_job_in_progress_panics_with_invalid_status() {
+        let (env, client, _, user, freelancer, native_token) = setup();
+
+        let job_id = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+
+        // Advance the job to InProgress
+        client.accept_job(&freelancer, &job_id);
+        assert_eq!(client.get_job(&job_id).status, JobStatus::InProgress);
+        client.cancel_job(&user, &job_id);
+    }
+
+    /// cancel_job must reject a job that has already reached Completed status.
+    /// A completed job has had its funds disbursed; cancellation at this point
+    /// must trigger Error::InvalidStatus (contract error code #3).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn cancel_job_completed_panics_with_invalid_status() {
+        let (env, client, _, user, freelancer, native_token) = setup();
+
+        let job_id = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+
+        // Drive the job through the full happy-path to Completed
+        client.accept_job(&freelancer, &job_id);
+        client.submit_work(&freelancer, &job_id);
+        client.approve_work(&user, &job_id);
+        assert_eq!(client.get_job(&job_id).status, JobStatus::Completed);
+
+        client.cancel_job(&user, &job_id);
+    }
 }


### PR DESCRIPTION
## Description
Adds three missing negative and authorization tests for `cancel_job` in the escrow contract. Without these tests, unauthorized callers and invalid status transitions were untested, leaving a gap in the contract's security coverage.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD change
- [x] Dependency update

## Related Issue
Closes #19

## Changes Made
- Add `cancel_job_unauthorized_caller_panics` — verifies a stranger address cannot cancel an Open job; expects `Error::Unauthorized` (contract error `#2`)
- Add `cancel_job_in_progress_panics_with_invalid_status` — verifies the legitimate client cannot cancel once a freelancer has accepted; expects `Error::InvalidStatus` (contract error `#3`)
- Add `cancel_job_completed_panics_with_invalid_status` — verifies the legitimate client cannot cancel a job that has already been approved and paid out; expects `Error::InvalidStatus` (contract error `#3`)

## Testing
- [x] New tests added for new behaviour

**Manual test steps (if applicable):**
Run `cargo test -p escrow` — all three new tests should pass alongside the existing suite.

## Migration Changes
- [x] No database migrations in this PR

## Documentation
- [x] No documentation changes needed

## Checklist
- [x] PR title follows Conventional Commits format (`type(scope): summary`)
- [x] No `console.log` / `println!` left in production code
- [x] No secrets, credentials, or `.env` files committed
- [x] Self-review completed — I have read my own diff

## Breaking Changes
None. Tests only — no production code modified.

## Additional Notes
All three tests use `#[should_panic(expected = "...")]` with the specific Soroban error string (`"Error(Contract, #2)"` for Unauthorized, `"Error(Contract, #3)"` for InvalidStatus) rather than a bare `#[should_panic]`, so a regression that panics for the wrong reason will still fail the test.