### PR TITLE
Add reusable UI components, jobs sorting, and admin transfer

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -392,6 +392,20 @@ impl EscrowContract {
         load_admin(&e)
     }
 
+    pub fn transfer_admin(e: Env, caller: Address, new_admin: Address) {
+        caller.require_auth();
+        let current_admin = load_admin(&e);
+        if caller != current_admin {
+            panic_with_error!(&e, Error::Unauthorized);
+        }
+        e.storage().instance().set(&DataKey::Admin, &new_admin);
+        bump_instance_ttl(&e);
+        e.events().publish(
+            (Symbol::new(&e, "admin_transferred"),),
+            (caller, new_admin),
+        );
+    }
+
     pub fn get_job_count(e: Env) -> u64 {
         get_jobs_count(&e)
     }
@@ -1120,5 +1134,22 @@ mod test {
     fn get_admin_public_view_returns_configured_admin() {
         let (_, client, admin, _, _, _) = setup();
         assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    fn transfer_admin_updates_admin() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        client.transfer_admin(&admin, &new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn transfer_admin_rejects_non_admin() {
+        let (env, client, _, _, _, _) = setup();
+        let caller = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        client.transfer_admin(&caller, &new_admin);
     }
 }

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -7,7 +7,9 @@ import {
   getNativeToken,
   withdrawFees,
 } from "@/lib/contract";
+import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
+import SectionCard from "@/components/SectionCard";
 import { useWallet } from "@/lib/wallet-context";
 import type { Job, JobStatus } from "@/lib/types";
 import { useEffect, useState, useCallback } from "react";
@@ -112,7 +114,7 @@ export default function AdminPage() {
     return (
       <section className="mx-auto max-w-3xl space-y-6">
         <h1 className="text-2xl font-semibold">Admin Panel</h1>
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
+        <SectionCard className="p-8 text-center">
           <p className="text-slate-600">Connect your wallet to access admin controls.</p>
           <button
             className="mt-4 rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white"
@@ -122,7 +124,7 @@ export default function AdminPage() {
           >
             Connect Wallet
           </button>
-        </div>
+        </SectionCard>
       </section>
     );
   }
@@ -167,8 +169,7 @@ export default function AdminPage() {
         </p>
       )}
 
-      <div className="rounded-lg border border-slate-200 bg-white p-5">
-        <h2 className="text-lg font-semibold">Platform Fees</h2>
+      <SectionCard title="Platform Fees">
         <p className="mt-2 text-3xl font-bold">{toXlm(fees)} XLM</p>
         <p className="text-sm text-slate-500">Accrued platform fees (2.5%)</p>
         <button
@@ -178,10 +179,9 @@ export default function AdminPage() {
         >
           {withdrawing ? "Withdrawing..." : "Withdraw Fees"}
         </button>
-      </div>
+      </SectionCard>
 
-      <div className="rounded-lg border border-slate-200 bg-white p-5">
-        <h2 className="text-lg font-semibold">Job Overview</h2>
+      <SectionCard title="Job Overview">
         <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
           <div className="rounded-md border border-slate-200 p-3 text-center">
             <p className="text-2xl font-bold">{jobs.length}</p>
@@ -197,12 +197,14 @@ export default function AdminPage() {
             </div>
           ))}
         </div>
-      </div>
+      </SectionCard>
 
-      <div className="rounded-lg border border-slate-200 bg-white p-5">
-        <h2 className="text-lg font-semibold">All Jobs</h2>
+      <SectionCard title="All Jobs">
         {jobs.length === 0 ? (
-          <p className="mt-3 text-sm text-slate-500">No jobs found on-chain.</p>
+          <EmptyState
+            title="No jobs found on-chain"
+            description="Jobs posted to the contract will appear in this table."
+          />
         ) : (
           <div className="mt-3 overflow-x-auto">
             <table className="w-full text-left text-sm">
@@ -249,7 +251,7 @@ export default function AdminPage() {
             </table>
           </div>
         )}
-      </div>
+      </SectionCard>
     </section>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -8,7 +8,9 @@ import {
   submitWork,
   enforceDeadline,
 } from "@/lib/contract";
+import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
+import SectionCard from "@/components/SectionCard";
 import { useWallet } from "@/lib/wallet-context";
 import type { Job, JobStatus } from "@/lib/types";
 import { useEffect, useState, useCallback } from "react";
@@ -108,7 +110,7 @@ export default function DashboardPage() {
     return (
       <section className="mx-auto max-w-3xl space-y-6">
         <h1 className="text-2xl font-semibold">Dashboard</h1>
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
+        <SectionCard className="p-8 text-center">
           <p className="text-slate-600">Connect your wallet to view your jobs.</p>
           <button
             className="mt-4 rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white"
@@ -118,7 +120,7 @@ export default function DashboardPage() {
           >
             Connect Wallet
           </button>
-        </div>
+        </SectionCard>
       </section>
     );
   }
@@ -196,9 +198,10 @@ function JobSection({
       <h2 className="text-lg font-semibold">{title}</h2>
       <p className="mb-3 text-sm text-slate-500">{subtitle}</p>
       {jobs.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-6 text-center">
-          <p className="text-sm text-slate-500">No jobs found.</p>
-        </div>
+        <EmptyState
+          title="No jobs found"
+          description="Try changing the status filter or check back after creating/accepting jobs."
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
           {jobs.map(({ id, job }) => (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import ErrorBanner from "@/components/ErrorBanner";
+import EmptyState from "@/components/EmptyState";
+import SectionCard from "@/components/SectionCard";
 import { acceptJob, getJob, getJobCount } from "@/lib/contract";
 import type { Job } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
@@ -20,6 +22,7 @@ export default function HomePage() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [totalJobs, setTotalJobs] = useState(0);
+  const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
 
   const totalPages = useMemo(
     () => Math.max(1, Math.ceil(totalJobs / pageSize)),
@@ -51,7 +54,10 @@ export default function HomePage() {
       const idsToFetch = Array.from(
         { length: endId - startId + 1 },
         (_, i) => String(startId + i),
-      ).reverse();
+      );
+      if (sortOrder === "newest") {
+        idsToFetch.reverse();
+      }
 
       const results = await Promise.all(
         idsToFetch.map(async (id) => {
@@ -75,7 +81,7 @@ export default function HomePage() {
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize]);
+  }, [page, pageSize, sortOrder]);
 
   useEffect(() => {
     void refresh();
@@ -110,8 +116,33 @@ export default function HomePage() {
       )}
 
       {!loading && jobs.length === 0 && !error && (
-        <p className="text-sm text-slate-600">No open jobs found.</p>
+        <EmptyState
+          title="No open jobs found"
+          description="New jobs will appear here as clients post them."
+        />
       )}
+
+      <SectionCard
+        title="Jobs Display"
+        description="Default sort is newest first."
+      >
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <label htmlFor="jobs-sort-order">Sort:</label>
+          <select
+            id="jobs-sort-order"
+            value={sortOrder}
+            onChange={(event) => {
+              setSortOrder(event.target.value as "newest" | "oldest");
+              setPage(1);
+            }}
+            className="rounded-md border border-slate-300 bg-white px-2 py-1"
+            disabled={loading}
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+          </select>
+        </div>
+      </SectionCard>
 
       <div className="grid gap-4 md:grid-cols-2">
         {jobs.map(({ id, job }) => (

--- a/frontend/components/EmptyState.tsx
+++ b/frontend/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+}
+
+export default function EmptyState({ title, description }: EmptyStateProps) {
+  return (
+    <div className="rounded-lg border border-dashed border-slate-300 bg-white p-6 text-center">
+      <p className="font-medium text-slate-700">{title}</p>
+      <p className="mt-1 text-sm text-slate-500">{description}</p>
+    </div>
+  );
+}

--- a/frontend/components/SectionCard.tsx
+++ b/frontend/components/SectionCard.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface SectionCardProps {
+  title?: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function SectionCard({
+  title,
+  description,
+  children,
+  className = "",
+}: SectionCardProps) {
+  return (
+    <div className={`rounded-lg border border-slate-200 bg-white p-5 ${className}`.trim()}>
+      {(title || description) && (
+        <div className="mb-3">
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          {description && <p className="text-sm text-slate-500">{description}</p>}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `SectionCard` and `EmptyState` components and apply them across `home`, `dashboard`, and `admin` pages
- add jobs sort dropdown on home with `Newest first` and `Oldest first`, with default sorting explicitly documented in UI
- add escrow `transfer_admin(caller, new_admin)` with strict current-admin authorization and event emission
- add escrow tests for successful admin transfer and non-admin rejection

## Validation
- started `cargo test` in `contracts/escrow` (backgrounded in session)
- started frontend dependency install + `npx vitest run` (backgrounded in session)
- no linter diagnostics on changed files

Closes #99
Closes #96
Closes #100
Closes #104

Made with [Cursor](https://cursor.com)