### PR TITLE
Fix #121 #123 #126 #129 with a11y and tests

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -66,6 +66,7 @@ pub enum Error {
     DeadlineNotExpired = 7,
     TokenNotAllowed = 8,
     RevisionLimitReached = 9,
+    AlreadyInitialized = 10,
 }
 
 #[contract]
@@ -75,7 +76,7 @@ pub struct EscrowContract;
 impl EscrowContract {
     pub fn initialize(e: Env, admin: Address, native_token: Address) {
         if e.storage().instance().has(&DataKey::Admin) {
-            return;
+            panic_with_error!(&e, Error::AlreadyInitialized);
         }
         admin.require_auth();
         e.storage().instance().set(&DataKey::Admin, &admin);
@@ -640,6 +641,24 @@ mod test {
 
     fn hash(env: &Env) -> BytesN<32> {
         BytesN::from_array(env, &[7; 32])
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn initialize_reinit_fails_explicitly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, EscrowContract);
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let native_token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        client.initialize(&admin, &native_token);
+        client.initialize(&admin, &native_token);
     }
 
     #[test]
@@ -1379,112 +1398,5 @@ mod test {
         let caller = Address::generate(&env);
         let new_admin = Address::generate(&env);
         client.transfer_admin(&caller, &new_admin);
-    }
-}
-#![no_std]
-
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, BytesN,
-    Env, Symbol,
-};
-
-const FEE_BPS: i128 = 250;
-const BPS_DENOMINATOR: i128 = 10_000;
-
-const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
-const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
-const ACTIVE_JOB_LIFETIME_THRESHOLD: u32 = 17_280;
-const ACTIVE_JOB_BUMP_AMOUNT: u32 = 518_400;
-const ARCHIVAL_JOB_BUMP_AMOUNT: u32 = 120_960;
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum JobStatus {
-    Open,
-    InProgress,
-    SubmittedForReview,
-    Completed,
-    Cancelled,
-    Disputed,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Job {
-    pub client: Address,
-    pub freelancer: Option<Address>,
-    pub amount: i128,
-    pub description_hash: BytesN<32>,
-    pub status: JobStatus,
-    pub created_at: u64,
-    pub deadline: u64,
-    pub token: Address,
-    pub submitted_at: u64,
-}
-
-    #[test]
-    fn get_contract_version_is_deterministic() {
-        let (_, client, _, _, _, _) = setup();
-        let first = client.get_contract_version();
-        let second = client.get_contract_version();
-        assert_eq!(first, CONTRACT_VERSION);
-        assert_eq!(first, second);
-    }
-
-    fn next_rand(state: &mut u64) -> u64 {
-        *state = state
-            .wrapping_mul(6_364_136_223_846_793_005)
-            .wrapping_add(1);
-        *state
-    }
-
-    #[test]
-    fn randomized_lifecycle_sequences_preserve_invariants() {
-        for run in 0..25u64 {
-            let (env, client, _, user, freelancer, native_token) = setup();
-            let mut rng = 0xC0FFEE_u64 ^ run;
-
-            for _ in 0..40 {
-                let amount = 100_000i128 + (next_rand(&mut rng) % 900_000) as i128;
-                let job_id = client.post_job(&user, &amount, &hash(&env), &0u64, &native_token);
-                let choice = next_rand(&mut rng) % 3;
-
-                if choice == 0 {
-                    client.cancel_job(&user, &job_id);
-                    let job = client.get_job(&job_id);
-                    assert_eq!(job.status, JobStatus::Cancelled);
-                    assert!(job.freelancer.is_none());
-                    continue;
-                }
-
-                client.accept_job(&freelancer, &job_id);
-                let accepted = client.get_job(&job_id);
-                assert_eq!(accepted.status, JobStatus::InProgress);
-                assert_eq!(accepted.freelancer, Option::Some(freelancer.clone()));
-
-                client.submit_work(&freelancer, &job_id);
-                let submitted = client.get_job(&job_id);
-                assert_eq!(submitted.status, JobStatus::SubmittedForReview);
-
-                if choice == 1 {
-                    client.approve_work(&user, &job_id);
-                    let completed = client.get_job(&job_id);
-                    assert_eq!(completed.status, JobStatus::Completed);
-                } else {
-                    client.raise_dispute(&user, &job_id);
-                    let disputed = client.get_job(&job_id);
-                    assert_eq!(disputed.status, JobStatus::Disputed);
-
-                    let winner_is_client = next_rand(&mut rng) % 2 == 0;
-                    if winner_is_client {
-                        client.resolve_dispute(&job_id, &user);
-                        assert_eq!(client.get_job(&job_id).status, JobStatus::Cancelled);
-                    } else {
-                        client.resolve_dispute(&job_id, &freelancer);
-                        assert_eq!(client.get_job(&job_id).status, JobStatus::Completed);
-                    }
-                }
-            }
-        }
     }
 }

--- a/contracts/escrow/test_snapshots/test/initialize_reinit_fails_explicitly.1.json
+++ b/contracts/escrow/test_snapshots/test/initialize_reinit_fails_explicitly.1.json
@@ -1,0 +1,761 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "AllowedToken"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllowedToken"
+                    },
+                    {
+                      "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bool": true
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "JobsCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "NativeToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": {
+              "bytes": "0000000161616100000000000000000000000000000000000000000000000000000000000000000000000004"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_admin"
+              },
+              {
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "8011bbf4cdf04e5bc6ac886935b99aa4b2c0cabde133f9d7fb3e656799f0a896",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "initialize"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "initialize"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "initialize"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 10
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "failing with contract error"
+                },
+                {
+                  "u32": 10
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 10
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 10
+                }
+              }
+            ],
+            "data": {
+              "string": "caught error from function"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 10
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract call failed"
+                },
+                {
+                  "symbol": "initialize"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    },
+                    {
+                      "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 10
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/frontend/__tests__/job-detail-actions.test.tsx
+++ b/frontend/__tests__/job-detail-actions.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import JobDetailPage from "@/app/job/[id]/page";
+import type { Job } from "@/lib/types";
+
+const mockGetJob = vi.fn();
+const mockUseWallet = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+}));
+
+vi.mock("@/lib/contract", () => ({
+  getJob: (...args: unknown[]) => mockGetJob(...args),
+  acceptJob: vi.fn(),
+  submitWork: vi.fn(),
+  approveWork: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    client: "GCLIENT",
+    freelancer: null,
+    amount: "10000000",
+    description_hash: "abc",
+    status: "Open",
+    created_at: "1710000000",
+    deadline: "0",
+    token: "GTOKEN",
+    revision_count: 0,
+    ...overrides,
+  };
+}
+
+describe("Job detail action visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWallet.mockReturnValue({
+      wallet: "GWALLET",
+      connectWallet: vi.fn(),
+    });
+  });
+
+  it("shows open-state actions correctly by role", async () => {
+    mockGetJob.mockResolvedValue(makeJob({ status: "Open", client: "GWALLET" }));
+    render(<JobDetailPage />);
+
+    await waitFor(() => expect(screen.getByText("Cancel Job")).toBeInTheDocument());
+    expect(screen.getByText("Accept Job")).toBeInTheDocument();
+    expect(screen.queryByText("Submit Work")).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve Work")).not.toBeInTheDocument();
+  });
+
+  it("shows submit action only for assigned freelancer in progress", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({
+        status: "InProgress",
+        client: "GCLIENT",
+        freelancer: "GWALLET",
+      }),
+    );
+    render(<JobDetailPage />);
+
+    await waitFor(() => expect(screen.getByText("Submit Work")).toBeInTheDocument());
+    expect(screen.queryByText("Approve Work")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cancel Job")).not.toBeInTheDocument();
+  });
+
+  it("shows approve action only for client in submitted state", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({
+        status: "SubmittedForReview",
+        client: "GWALLET",
+        freelancer: "GFREELANCER",
+      }),
+    );
+    render(<JobDetailPage />);
+
+    await waitFor(() => expect(screen.getByText("Approve Work")).toBeInTheDocument());
+    expect(screen.queryByText("Submit Work")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cancel Job")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9,6 +9,11 @@ body {
   font-family: var(--font-geist-sans);
 }
 
+:root {
+  /* Raise muted text contrast while preserving existing utility classes. */
+  --color-slate-600: #334155;
+}
+
 @layer base {
   button:focus-visible, 
   a:focus-visible, 

--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -17,6 +17,7 @@ export default function JobDetailPage() {
   const [job, setJob] = useState<Job | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [lastAnnouncedSuccess, setLastAnnouncedSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(true);
   const [latestTxHash, setLatestTxHash] = useState<string | null>(null);
@@ -72,7 +73,11 @@ export default function JobDetailPage() {
         setLatestTxHash(result.hash);
       }
       await load();
-      setStatusMsg("Action completed successfully.");
+      const nextSuccess = "Action completed successfully.";
+      setStatusMsg(nextSuccess);
+      if (nextSuccess !== lastAnnouncedSuccess) {
+        setLastAnnouncedSuccess(nextSuccess);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Transaction failed.");
     } finally {
@@ -85,7 +90,7 @@ export default function JobDetailPage() {
       <div className="py-16">
         <LoadingState
           text="Loading job details..."
-          className="mx-auto flex w-fit items-center gap-2 text-sm text-slate-600"
+          className="mx-auto flex w-fit items-center gap-2 text-sm text-slate-700"
         />
       </div>
     );
@@ -95,7 +100,7 @@ export default function JobDetailPage() {
     return (
       <section className="space-y-4">
         <h1 className="text-2xl font-semibold">Job #{id}</h1>
-        <p className="text-sm text-slate-600">{error ?? "Job not found."}</p>
+        <p className="text-sm text-slate-700">{error ?? "Job not found."}</p>
         <Link href="/" className="text-sm text-blue-600 hover:underline">
           Back to Home
         </Link>
@@ -118,12 +123,17 @@ export default function JobDetailPage() {
         </p>
       )}
       {statusMsg && (
-        <p role="status" aria-live="polite" className="rounded-md bg-green-100 p-3 text-sm text-green-700">
+        <p
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="rounded-md bg-green-100 p-3 text-sm text-green-700"
+        >
           {statusMsg}
         </p>
       )}
       {latestTxHash && (
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-700">
           Last transaction:{" "}
           <a
             href={getExplorerTxUrl(latestTxHash)}

--- a/frontend/app/post-job/page.tsx
+++ b/frontend/app/post-job/page.tsx
@@ -24,6 +24,7 @@ export default function PostJobPage() {
   );
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [lastAnnouncedSuccess, setLastAnnouncedSuccess] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -63,7 +64,12 @@ export default function PostJobPage() {
               setTxHash(result.hash);
             }
             const jobId = typeof result === "number" || typeof result === "string" ? result : null;
-            setSuccess(jobId != null ? `Job #${jobId} created successfully.` : "Job submitted to contract.");
+            const successMessage =
+              jobId != null ? `Job #${jobId} created successfully.` : "Job submitted to contract.";
+            setSuccess(successMessage);
+            if (successMessage !== lastAnnouncedSuccess) {
+              setLastAnnouncedSuccess(successMessage);
+            }
             setAmount("");
             setDescription("");
             setDeadline("");
@@ -129,9 +135,13 @@ export default function PostJobPage() {
       </form>
 
       {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
-      {success && <p role="status" aria-live="polite" className="rounded-md bg-green-100 p-3 text-sm text-green-700">{success}</p>}
+      {success && (
+        <p role="status" aria-live="polite" aria-atomic="true" className="rounded-md bg-green-100 p-3 text-sm text-green-700">
+          {success}
+        </p>
+      )}
       {txHash && (
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-700">
           Transaction:{" "}
           <a
             href={getExplorerTxUrl(txHash)}

--- a/frontend/components/LoadingState.tsx
+++ b/frontend/components/LoadingState.tsx
@@ -10,7 +10,8 @@ export default function LoadingState({ text, className }: LoadingStateProps) {
     <div
       role="status"
       aria-live="polite"
-      className={className ?? "flex items-center gap-2 text-sm text-slate-600"}
+      aria-atomic="true"
+      className={className ?? "flex items-center gap-2 text-sm text-slate-700"}
     >
       <span
         className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"


### PR DESCRIPTION
## Summary
- improve muted text contrast globally for existing `text-slate-600` usage by overriding the token to a WCAG-safer shade
- harden polite async success announcements with `aria-live=\"polite\"` + `aria-atomic=\"true\"` in job and post-job flows
- add frontend component tests for role/status-gated actions on job detail and contract test coverage for initialize re-init failure

## Issues closed
Closes #121
Closes #123
Closes #126
Closes #129

## Test plan
- `cargo test initialize_reinit_fails_explicitly` (pass)
- `npm test -- __tests__/job-detail-actions.test.tsx` (pending local dependency install completion)

Made with [Cursor](https://cursor.com)