### PR TITLE
Implement profile metadata routing and add coverage for wallet, forma…

### DIFF
--- a/frontend/__tests__/format.test.ts
+++ b/frontend/__tests__/format.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { toXlm } from "@/lib/format";
+
+describe("toXlm", () => {
+  it("formats common stroop amounts", () => {
+    expect(toXlm("10000000")).toBe("1.00");
+    expect(toXlm(25000000)).toBe("2.50");
+    expect(toXlm(BigInt(123456789))).toBe("12.35");
+  });
+
+  it("covers edge values", () => {
+    expect(toXlm(0)).toBe("0.00");
+    expect(toXlm("1")).toBe("0.00");
+    expect(toXlm(-10000000)).toBe("-1.00");
+  });
+
+  it("applies rounding to 2 decimals", () => {
+    expect(toXlm(10050000)).toBe("1.01");
+    expect(toXlm(10049999)).toBe("1.00");
+  });
+});

--- a/frontend/__tests__/job-detail-actions.test.tsx
+++ b/frontend/__tests__/job-detail-actions.test.tsx
@@ -6,9 +6,10 @@ import type { Job } from "@/lib/types";
 
 const mockGetJob = vi.fn();
 const mockUseWallet = vi.fn();
+let mockRouteId = "1";
 
 vi.mock("next/navigation", () => ({
-  useParams: () => ({ id: "1" }),
+  useParams: () => ({ id: mockRouteId }),
 }));
 
 vi.mock("@/lib/contract", () => ({
@@ -41,6 +42,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
 describe("Job detail action visibility", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRouteId = "1";
     mockUseWallet.mockReturnValue({
       wallet: "GWALLET",
       connectWallet: vi.fn(),
@@ -100,5 +102,17 @@ describe("Job detail action visibility", () => {
     expect(
       screen.getByText("Connect your wallet to enable contract actions."),
     ).toBeInTheDocument();
+  });
+
+  it("shows not found error path for missing job ids", async () => {
+    mockRouteId = "999";
+    mockGetJob.mockResolvedValue(null);
+
+    render(<JobDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Job not found.")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("heading", { name: "Job #999" })).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/profile-metadata.test.ts
+++ b/frontend/__tests__/profile-metadata.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { generateMetadata } from "@/app/profile/[address]/page";
+
+describe("profile route metadata", () => {
+  it("includes valid route address in title", async () => {
+    const address = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+    const metadata = await generateMetadata({
+      params: { address },
+    });
+
+    expect(metadata.title).toBe(`Profile | ${address} | StellarWork`);
+    expect(metadata.description).toContain(address);
+  });
+
+  it("returns fallback title for invalid address", async () => {
+    const metadata = await generateMetadata({
+      params: { address: "not-a-stellar-address" },
+    });
+
+    expect(metadata.title).toBe("Profile | Invalid Address | StellarWork");
+  });
+});

--- a/frontend/__tests__/wallet-context.test.tsx
+++ b/frontend/__tests__/wallet-context.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WalletProvider, useWallet } from "@/lib/wallet-context";
+
+const mockConnectWallet = vi.fn();
+const mockGetPublicKey = vi.fn();
+
+vi.mock("@/lib/stellar", () => ({
+  connectWallet: (...args: unknown[]) => mockConnectWallet(...args),
+  getPublicKey: (...args: unknown[]) => mockGetPublicKey(...args),
+}));
+
+function WalletProbe() {
+  const { wallet, connectWallet, disconnectWallet } = useWallet();
+  return (
+    <div>
+      <p data-testid="wallet">{wallet ?? "none"}</p>
+      <button type="button" onClick={() => void connectWallet()}>
+        connect
+      </button>
+      <button type="button" onClick={disconnectWallet}>
+        disconnect
+      </button>
+    </div>
+  );
+}
+
+function WalletErrorProbe() {
+  const { connectWallet } = useWallet();
+  const [error, setError] = React.useState("none");
+
+  return (
+    <div>
+      <p data-testid="error">{error}</p>
+      <button
+        type="button"
+        onClick={async () => {
+          try {
+            await connectWallet();
+          } catch (err) {
+            setError(err instanceof Error ? err.message : "unknown");
+          }
+        }}
+      >
+        connect with error handling
+      </button>
+    </div>
+  );
+}
+
+describe("WalletProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates provider state to consumers", async () => {
+    mockGetPublicKey.mockResolvedValue("GINITIALWALLET");
+
+    render(
+      <WalletProvider>
+        <WalletProbe />
+      </WalletProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet")).toHaveTextContent("GINITIALWALLET"),
+    );
+  });
+
+  it("handles connect and disconnect behavior", async () => {
+    mockGetPublicKey.mockResolvedValue(null);
+    mockConnectWallet.mockResolvedValue("GCONNECTEDWALLET");
+
+    render(
+      <WalletProvider>
+        <WalletProbe />
+      </WalletProvider>,
+    );
+
+    expect(screen.getByTestId("wallet")).toHaveTextContent("none");
+
+    fireEvent.click(screen.getByRole("button", { name: "connect" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet")).toHaveTextContent("GCONNECTEDWALLET"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "disconnect" }));
+    expect(screen.getByTestId("wallet")).toHaveTextContent("none");
+  });
+
+  it("surfaces connect errors to consumer callers", async () => {
+    mockGetPublicKey.mockResolvedValue(null);
+    mockConnectWallet.mockRejectedValue(new Error("freighter unavailable"));
+
+    render(
+      <WalletProvider>
+        <WalletErrorProbe />
+      </WalletProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "connect with error handling" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("error")).toHaveTextContent(
+        "freighter unavailable",
+      ),
+    );
+  });
+});

--- a/frontend/app/profile/[address]/page.tsx
+++ b/frontend/app/profile/[address]/page.tsx
@@ -1,215 +1,41 @@
-"use client";
-
-import { getJob, getJobCount } from "@/lib/contract";
-import ErrorBanner from "@/components/ErrorBanner";
-import { useWallet } from "@/lib/wallet-context";
-import type { Job, JobStatus } from "@/lib/types";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useEffect, useState, useCallback } from "react";
-
-const STATUS_LABELS: Record<JobStatus, string> = {
-  Open: "Open",
-  InProgress: "In Progress",
-  SubmittedForReview: "Submitted for Review",
-  Completed: "Completed",
-  Cancelled: "Cancelled",
-  Disputed: "Disputed",
-};
-
-const STATUS_COLORS: Record<JobStatus, string> = {
-  Open: "bg-blue-100 text-blue-800",
-  InProgress: "bg-yellow-100 text-yellow-800",
-  SubmittedForReview: "bg-purple-100 text-purple-800",
-  Completed: "bg-green-100 text-green-800",
-  Cancelled: "bg-red-100 text-red-800",
-  Disputed: "bg-orange-100 text-orange-800",
-};
+import type { Metadata } from "next";
+import ProfilePageClient from "./profile-page-client";
 
 function isValidStellarAddress(address: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(address);
 }
 
-function toXlm(stroops: number) {
-  return (stroops / 10_000_000).toFixed(2);
-}
+type RouteParams = { address: string };
 
-interface ProfileJob {
-  id: number;
-  job: Job;
-  role: "client" | "freelancer";
-}
+type MetadataProps = {
+  params: Promise<RouteParams> | RouteParams;
+};
 
-export default function ProfilePage() {
-  const params = useParams<{ address: string }>();
-  const address = params.address;
-  const { wallet, connectWallet } = useWallet();
+export async function generateMetadata({
+  params,
+}: MetadataProps): Promise<Metadata> {
+  const resolvedParams = await params;
+  const address = resolvedParams.address;
+  const isValidAddress = isValidStellarAddress(address);
 
-  const [jobs, setJobs] = useState<ProfileJob[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const addressValid = isValidStellarAddress(address);
-
-  const fetchJobs = useCallback(async () => {
-    if (!wallet || !addressValid) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const count = await getJobCount();
-      const fetched: ProfileJob[] = [];
-      for (let id = 1; id <= count; id += 1) {
-        const job = await getJob(String(id));
-        if (!job) continue;
-        if (job.client === address) {
-          fetched.push({ id, job, role: "client" });
-        } else if (job.freelancer === address) {
-          fetched.push({ id, job, role: "freelancer" });
-        }
-      }
-      setJobs(fetched);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to fetch job history.");
-    } finally {
-      setLoading(false);
-    }
-  }, [wallet, address, addressValid]);
-
-  useEffect(() => {
-    fetchJobs();
-  }, [fetchJobs]);
-
-  const jobsPosted = jobs.filter((j) => j.role === "client").length;
-  const jobsCompleted = jobs.filter((j) => j.job.status === "Completed").length;
-  const totalEarnedStroops = jobs
-    .filter((j) => j.role === "freelancer" && j.job.status === "Completed")
-    .reduce((sum, j) => sum + Number(j.job.amount) * 0.975, 0);
-  const totalSpentStroops = jobs
-    .filter((j) => j.role === "client" && j.job.status === "Completed")
-    .reduce((sum, j) => sum + Number(j.job.amount), 0);
-
-  if (!addressValid) {
-    return (
-      <section className="mx-auto max-w-3xl space-y-6">
-        <h1 className="text-2xl font-semibold">Profile</h1>
-        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
-          <p className="font-medium text-red-800">Invalid Address</p>
-          <p className="mt-1 text-sm text-red-600">
-            &ldquo;{address}&rdquo; is not a valid Stellar address.
-          </p>
-        </div>
-      </section>
-    );
+  if (!isValidAddress) {
+    return {
+      title: "Profile | Invalid Address | StellarWork",
+      description: "Invalid Stellar address supplied for profile lookup.",
+    };
   }
 
-  if (!wallet) {
-    return (
-      <section className="mx-auto max-w-3xl space-y-6">
-        <h1 className="text-2xl font-semibold">Profile</h1>
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
-          <p className="text-slate-600">Connect your wallet to view this profile.</p>
-          <button
-            className="mt-4 rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white"
-            onClick={async () => {
-              try { await connectWallet(); } catch { /* cancelled */ }
-            }}
-          >
-            Connect Wallet
-          </button>
-        </div>
-      </section>
-    );
-  }
+  return {
+    title: `Profile | ${address} | StellarWork`,
+    description: `View on-chain profile activity for ${address}.`,
+  };
+}
 
-  return (
-    <section className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Profile</h1>
-        <p className="mt-1 font-mono text-sm text-slate-500">{address}</p>
-      </div>
+type PageProps = {
+  params: Promise<RouteParams> | RouteParams;
+};
 
-      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
-      {loading && <p className="text-sm text-slate-600">Loading job history...</p>}
-
-      {!loading && (
-        <>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">{jobsPosted}</p>
-              <p className="text-xs text-slate-500">Jobs Posted</p>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">{jobsCompleted}</p>
-              <p className="text-xs text-slate-500">Jobs Completed</p>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">
-                {toXlm(totalEarnedStroops)}
-              </p>
-              <p className="text-xs text-slate-500">XLM Earned</p>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">
-                {toXlm(totalSpentStroops)}
-              </p>
-              <p className="text-xs text-slate-500">XLM Spent</p>
-            </div>
-          </div>
-
-          <div className="rounded-lg border border-slate-200 bg-white p-5">
-            <h2 className="text-lg font-semibold">Job History</h2>
-            {jobs.length === 0 ? (
-              <p className="mt-3 text-sm text-slate-500">
-                No jobs found for this address.
-              </p>
-            ) : (
-              <div className="mt-3 overflow-x-auto">
-                <table className="w-full text-left text-sm">
-                  <thead>
-                    <tr className="border-b border-slate-200 text-xs text-slate-500">
-                      <th className="pb-2 pr-4">ID</th>
-                      <th className="pb-2 pr-4">Role</th>
-                      <th className="pb-2 pr-4">Status</th>
-                      <th className="pb-2 pr-4 text-right">Amount</th>
-                      <th className="pb-2 pr-4">Date</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {jobs.map(({ id, job, role }) => (
-                      <tr key={`${id}-${role}`} className="border-b border-slate-100">
-                        <td className="py-2 pr-4">
-                          <Link
-                            href={`/job/${id}`}
-                            className="font-medium hover:underline"
-                          >
-                            #{id}
-                          </Link>
-                        </td>
-                        <td className="py-2 pr-4 capitalize">{role}</td>
-                        <td className="py-2 pr-4">
-                          <span
-                            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
-                          >
-                            {STATUS_LABELS[job.status]}
-                          </span>
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {toXlm(Number(job.amount))} XLM
-                        </td>
-                        <td className="py-2 pr-4 text-xs">
-                          {new Date(
-                            Number(job.created_at) * 1000,
-                          ).toLocaleDateString()}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        </>
-      )}
-    </section>
-  );
+export default async function ProfilePage({ params }: PageProps) {
+  const resolvedParams = await params;
+  return <ProfilePageClient address={resolvedParams.address} />;
 }

--- a/frontend/app/profile/[address]/profile-page-client.tsx
+++ b/frontend/app/profile/[address]/profile-page-client.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import ErrorBanner from "@/components/ErrorBanner";
+import { getJob, getJobCount } from "@/lib/contract";
+import type { Job, JobStatus } from "@/lib/types";
+import { useWallet } from "@/lib/wallet-context";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  Open: "Open",
+  InProgress: "In Progress",
+  SubmittedForReview: "Submitted for Review",
+  Completed: "Completed",
+  Cancelled: "Cancelled",
+  Disputed: "Disputed",
+};
+
+const STATUS_COLORS: Record<JobStatus, string> = {
+  Open: "bg-blue-100 text-blue-800",
+  InProgress: "bg-yellow-100 text-yellow-800",
+  SubmittedForReview: "bg-purple-100 text-purple-800",
+  Completed: "bg-green-100 text-green-800",
+  Cancelled: "bg-red-100 text-red-800",
+  Disputed: "bg-orange-100 text-orange-800",
+};
+
+function isValidStellarAddress(address: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(address);
+}
+
+function toXlm(stroops: number) {
+  return (stroops / 10_000_000).toFixed(2);
+}
+
+interface ProfileJob {
+  id: number;
+  job: Job;
+  role: "client" | "freelancer";
+}
+
+export default function ProfilePageClient({ address }: { address: string }) {
+  const { wallet, connectWallet } = useWallet();
+
+  const [jobs, setJobs] = useState<ProfileJob[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addressValid = isValidStellarAddress(address);
+
+  const fetchJobs = useCallback(async () => {
+    if (!wallet || !addressValid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const count = await getJobCount();
+      const fetched: ProfileJob[] = [];
+      for (let id = 1; id <= count; id += 1) {
+        const job = await getJob(String(id));
+        if (!job) continue;
+        if (job.client === address) {
+          fetched.push({ id, job, role: "client" });
+        } else if (job.freelancer === address) {
+          fetched.push({ id, job, role: "freelancer" });
+        }
+      }
+      setJobs(fetched);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch job history.");
+    } finally {
+      setLoading(false);
+    }
+  }, [wallet, address, addressValid]);
+
+  useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  const jobsPosted = jobs.filter((j) => j.role === "client").length;
+  const jobsCompleted = jobs.filter((j) => j.job.status === "Completed").length;
+  const totalEarnedStroops = jobs
+    .filter((j) => j.role === "freelancer" && j.job.status === "Completed")
+    .reduce((sum, j) => sum + Number(j.job.amount) * 0.975, 0);
+  const totalSpentStroops = jobs
+    .filter((j) => j.role === "client" && j.job.status === "Completed")
+    .reduce((sum, j) => sum + Number(j.job.amount), 0);
+
+  if (!addressValid) {
+    return (
+      <section className="mx-auto max-w-3xl space-y-6">
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+          <p className="font-medium text-red-800">Invalid Address</p>
+          <p className="mt-1 text-sm text-red-600">
+            &ldquo;{address}&rdquo; is not a valid Stellar address.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (!wallet) {
+    return (
+      <section className="mx-auto max-w-3xl space-y-6">
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
+          <p className="text-slate-600">Connect your wallet to view this profile.</p>
+          <button
+            className="mt-4 rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white"
+            onClick={async () => {
+              try {
+                await connectWallet();
+              } catch {
+                // user cancelled wallet connect flow
+              }
+            }}
+          >
+            Connect Wallet
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <p className="mt-1 font-mono text-sm text-slate-500">{address}</p>
+      </div>
+
+      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
+      {loading && <p className="text-sm text-slate-600">Loading job history...</p>}
+
+      {!loading && (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
+              <p className="text-2xl font-bold">{jobsPosted}</p>
+              <p className="text-xs text-slate-500">Jobs Posted</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
+              <p className="text-2xl font-bold">{jobsCompleted}</p>
+              <p className="text-xs text-slate-500">Jobs Completed</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
+              <p className="text-2xl font-bold">{toXlm(totalEarnedStroops)}</p>
+              <p className="text-xs text-slate-500">XLM Earned</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
+              <p className="text-2xl font-bold">{toXlm(totalSpentStroops)}</p>
+              <p className="text-xs text-slate-500">XLM Spent</p>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-slate-200 bg-white p-5">
+            <h2 className="text-lg font-semibold">Job History</h2>
+            {jobs.length === 0 ? (
+              <p className="mt-3 text-sm text-slate-500">
+                No jobs found for this address.
+              </p>
+            ) : (
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 text-xs text-slate-500">
+                      <th className="pb-2 pr-4">ID</th>
+                      <th className="pb-2 pr-4">Role</th>
+                      <th className="pb-2 pr-4">Status</th>
+                      <th className="pb-2 pr-4 text-right">Amount</th>
+                      <th className="pb-2 pr-4">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {jobs.map(({ id, job, role }) => (
+                      <tr key={`${id}-${role}`} className="border-b border-slate-100">
+                        <td className="py-2 pr-4">
+                          <Link href={`/job/${id}`} className="font-medium hover:underline">
+                            #{id}
+                          </Link>
+                        </td>
+                        <td className="py-2 pr-4 capitalize">{role}</td>
+                        <td className="py-2 pr-4">
+                          <span
+                            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
+                          >
+                            {STATUS_LABELS[job.status]}
+                          </span>
+                        </td>
+                        <td className="py-2 pr-4 text-right">
+                          {toXlm(Number(job.amount))} XLM
+                        </td>
+                        <td className="py-2 pr-4 text-xs">
+                          {new Date(Number(job.created_at) * 1000).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

This PR completes four assigned open-source contributions in a single branch:

- Added dynamic metadata for the profile route so page titles include the profile address context.
- Added shared wallet provider tests to validate connect/disconnect flow, consumer state propagation, and error handling.
- Added unit tests for amount formatting helper behavior, including edge cases and rounding assertions.
- Added a missing job ID test to verify the job detail page follows the expected "not found" error path.

## Changes

### 1) Profile route metadata updates

- Refactored `frontend/app/profile/[address]/page.tsx` to support server-side `generateMetadata`.
- Added route-aware metadata behavior:
  - Valid address: `Profile | <address> | StellarWork`
  - Invalid address fallback: `Profile | Invalid Address | StellarWork`
- Moved existing client-rendered profile UI into:
  - `frontend/app/profile/[address]/profile-page-client.tsx`

### 2) Wallet provider test coverage

Added `frontend/__tests__/wallet-context.test.tsx` to cover:

- Wallet state propagation from provider to consumers.
- Connect and disconnect behavior.
- Error path when wallet connection fails.

### 3) Amount formatting helper tests

Added `frontend/__tests__/format.test.ts` to validate `toXlm` behavior for:

- Normal values.
- Edge values (zero, small stroop values, negative values).
- Correct 2-decimal rounding.

### 4) Missing job ID error path test

Updated `frontend/__tests__/job-detail-actions.test.tsx` with a case that:

- Simulates a missing job ID (`getJob` returns `null`).
- Asserts expected not-found error UI (`Job not found.`).

## Files Added

- `frontend/app/profile/[address]/profile-page-client.tsx`
- `frontend/__tests__/wallet-context.test.tsx`
- `frontend/__tests__/format.test.ts`
- `frontend/__tests__/profile-metadata.test.ts`

## Files Updated

- `frontend/app/profile/[address]/page.tsx`
- `frontend/__tests__/job-detail-actions.test.tsx`

## Test Plan

- [ ] Run frontend unit tests:
  - `cd frontend`
  - `npm test`
- [ ] Confirm profile page title behavior manually:
  - Valid address route shows address in title.
  - Invalid address route shows fallback title.
- [ ] Confirm all existing tests remain green in CI.

## Notes

- This PR is scoped to implementation and tests only.
- No unnecessary files or unrelated refactors are included.

closes #117 
closes #127 
closes #124 
closes #130 