### PR TITLE
feat: docs add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Project Maintainers
+
+This file lists the individuals who have the authority to merge pull requests and set the project's technical direction.
+
+## Active Maintainers
+
+| Maintainer | GitHub ID | Primary Areas of Ownership |
+| :--- | :--- | :--- |
+| **Anu Mukul** | [@anumukul](https://github.com/anumukul) | Smart Contracts, Architecture, Core Logic |
+| **Kay Azumi** | [@devkayazumi](https://github.com/devkayazumi) | Frontend, User Experience, Web Integration |
+
+## Areas of Ownership
+
+- **Smart Contracts (`/contracts`)**: Responsibility of [@anumukul](https://github.com/anumukul). Any changes to Soroban logic or contract interfaces require their explicit approval.
+- **Frontend (`/frontend`)**: Responsibility of [@devkayazumi](https://github.com/devkayazumi). UI/UX refinements, API integrations, and state management updates fall under this area.
+- **Documentation & Infrastructure**: Shared responsibility. Pull requests involving documentation, CI/CD, or project management can be reviewed by any active maintainer.
+
+## Update Process
+
+1. **Adding Maintainers**: New maintainers are added based on consistent high-quality contributions and a deep understanding of the project's goals. This is decided by consensus among existing maintainers.
+2. **Stepping Down**: If a maintainer is no longer active or able to fulfill their duties, they should move themselves to an "Emeritus" section (if one exists) or remove their name from the active list via a PR.
+3. **Modifying this File**: Any changes to this file must be proposed via a Pull Request and approved by the project owner.
+
+---
+*Last Updated: 2026-04-29*


### PR DESCRIPTION
## Description
This PR adds a `MAINTAINERS.md` file to the project. As the project grows, it is important to clearly define who has authority over different parts of the codebase (e.g., smart contracts vs. frontend) and how the maintainer list is managed.

## Key Changes
- Created `MAINTAINERS.md` with a list of active maintainers.
- Defined specific areas of ownership for core contributors.
- Documented the maintainer update and retirement process.

## Acceptance Criteria
- [x] Maintainers file added.
- [x] Areas of ownership listed.
- [x] Update process documented.

Fixes #184
