### PR TITLE
docs: document created_at unit definition, example values, and contract behavior (#176)

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -19,7 +19,22 @@ Location: `contracts/escrow/src/lib.rs`
 
 ## Data Model
 
-- `Job`: `client`, `freelancer`, `amount`, `description_hash`, `status`, `created_at`, `deadline`
+### `Job` struct
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `client` | `Address` | The account that created and funded the job. |
+| `freelancer` | `Option<Address>` | The account assigned to the job (`None` until accepted). |
+| `amount` | `i128` | Total payment held in escrow (in the token's smallest unit). |
+| `description_hash` | `BytesN<32>` | SHA-256 hash of the job description (all-zero hash is rejected). |
+| `status` | `JobStatus` | Current lifecycle state of the job. |
+| `created_at` | `u64` | **Unix epoch seconds** — set by `e.ledger().timestamp()` at `post_job` time. Read-only after creation. Example: `1710000000` (≈ 2024-03-10 UTC). |
+| `deadline` | `u64` | **Unix epoch seconds** — the latest time the job is active. Use `0` for no deadline. Example: `1712592000` (≈ 2024-04-09 UTC, 30 days after the example `created_at`). |
+| `token` | `Address` | The whitelisted token contract used for payment. |
+| `revision_count` | `u32` | Number of times the client has rejected submitted work (max 3). |
+
+> **Note on `created_at` vs `deadline`:** Both fields use the same unit — Unix epoch **seconds** from the Soroban ledger clock (`e.ledger().timestamp()`). They are never wall-clock timestamps supplied by the caller. `created_at` is always immutable. `deadline == 0` means no expiry enforced.
+
 - `JobStatus`: `Open`, `InProgress`, `SubmittedForReview`, `Completed`, `Cancelled`, `Disputed`
 
 ## Error Codes

--- a/docs/contract-reference.md
+++ b/docs/contract-reference.md
@@ -38,8 +38,15 @@ This document provides a quick reference for the `EscrowContract` methods, expec
 - `amount: i128`: Total job payment held in escrow.
 - `description_hash: BytesN<32>`: SHA-256 hash of the job description.
 - `status: JobStatus`: Current state of the job.
-- `created_at: u64`: Ledger timestamp of job creation.
-- `deadline: u64`: Ledger timestamp after which the job can be cancelled (0 if none).
+- `created_at: u64`: Ledger timestamp (Unix epoch, **seconds**) recorded at the moment `post_job` is called.
+  - Set by the contract via `e.ledger().timestamp()` — callers cannot supply or override this value.
+  - Immutable after job creation; never updated by subsequent state transitions.
+  - **Example:** `1710000000` (≈ 2024-03-10 00:00:00 UTC)
+  - Useful for calculating job age: `age_seconds = current_ledger_timestamp - created_at`.
+- `deadline: u64`: Ledger timestamp (Unix epoch, **seconds**) after which the job may be cancelled by the client via `enforce_deadline`. Pass `0` to indicate no deadline.
+  - **Example (no deadline):** `0`
+  - **Example (30-day deadline):** `1710000000 + 2_592_000` = `1712592000` (≈ 2024-04-09 UTC)
+  - The contract validates at `post_job` and `accept_job` that `deadline == 0 || current_timestamp <= deadline`.
 - `token: Address`: The token used for payment.
 - `revision_count: u32`: Number of times the client has rejected work.
 


### PR DESCRIPTION
Fixes #176

### Summary
This PR clarifies the `created_at` field in the `Job` struct across the documentation to resolve ambiguity around its unit, source, and behaviour.

### Changes

**`docs/contract-reference.md`**
- Expanded `created_at` entry to specify it is **Unix epoch seconds** sourced from `e.ledger().timestamp()`.
- Added a note that it is **set by the contract** at `post_job` time — callers cannot supply or override it.
- Added note that it is **immutable** after job creation.
- Added concrete example value: `1710000000` (≈ 2024-03-10 UTC).
- Added usage hint: `age_seconds = current_ledger_timestamp - created_at`.
- Expanded `deadline` with the same unit clarification and two example values (no-deadline `0`, and a 30-day deadline).

**`docs/CONTRACT.md`**
- Replaced the bare field list under `Data Model` with a full markdown table including types and descriptions for all fields.
- Added a callout note explaining that both `created_at` and `deadline` use the same Soroban ledger clock unit (Unix epoch seconds), are never caller-supplied timestamps, and that `deadline == 0` means no expiry enforced.

### Acceptance Criteria
- [x] Docs include field unit definition (`u64` = Unix epoch **seconds**)
- [x] Example values added (`1710000000`, `1712592000`)
- [x] Notes match contract behavior (`e.ledger().timestamp()`, immutability, `deadline == 0` sentinel)
