### PR TITLE
fix: preserve expected scroll behavior on route changes (#169)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9,6 +9,12 @@ body {
   font-family: var(--font-geist-sans);
 }
 
+html {
+  /* Smooth anchor scrolling for hash deep-links.
+     Overridden to 'auto' by the prefers-reduced-motion rule below. */
+  scroll-behavior: smooth;
+}
+
 :root {
   /* Raise muted text contrast while preserving existing utility classes. */
   --color-slate-600: #334155;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { WalletProvider } from "@/lib/wallet-context";
 import { Navigation } from "./navigation";
+import { ScrollRestorer } from "@/components/ScrollRestorer";
 import Link from "next/link";
 import "./globals.css";
 
@@ -39,6 +40,7 @@ export default function RootLayout({
             Skip to main content
           </a>
           <Navigation />
+          <ScrollRestorer />
           <main id="main-content" className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">{children}</main>
           <footer className="mt-auto border-t border-slate-200 bg-white py-8">
             <div className="mx-auto max-w-5xl px-4">

--- a/frontend/app/navigation.tsx
+++ b/frontend/app/navigation.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useWallet, WalletButton } from "@/lib/wallet-context";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export function Navigation() {
   const pathname = usePathname();

--- a/frontend/components/ScrollRestorer.tsx
+++ b/frontend/components/ScrollRestorer.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * ScrollRestorer
+ *
+ * Handles scroll behavior on route transitions in the Next.js App Router:
+ *
+ * 1. Hash links (deep-links): When the URL contains a `#fragment`, the browser
+ *    native anchor scroll is preserved. We do NOT override it.
+ *
+ * 2. New-page navigation (no hash): Scroll is instantly reset to the top of the
+ *    page without any visible jump, because the reset happens synchronously
+ *    before the browser paints the new page content.
+ *
+ * 3. Same-pathname hash changes: When only the hash changes on the same path
+ *    (e.g. clicking a TOC link), we let the browser handle the anchor scroll
+ *    natively — no interference.
+ *
+ * This component must be rendered inside the root layout so it is mounted for
+ * the entire session and reacts to every pathname change.
+ */
+export function ScrollRestorer() {
+  const pathname = usePathname();
+  const prevPathnameRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Read the hash *after* the navigation has committed so the URL is current.
+    const hash = window.location.hash;
+
+    // If the page has a deep-link hash, let the browser scroll to the anchor
+    // natively. We only reset scroll on plain page navigations.
+    if (hash) {
+      // The browser already handles scrolling to the anchor element, but the
+      // element may not exist yet if content is streamed / async. Attempt a
+      // deferred scroll-into-view as a fallback without disrupting the normal
+      // case.
+      const id = hash.slice(1); // strip leading '#'
+      const el = document.getElementById(id);
+      if (el) {
+        // Element already in DOM — scroll immediately.
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else {
+        // Element not yet rendered (e.g. lazy section). Try once after a short
+        // delay so streamed content has time to mount.
+        const timer = setTimeout(() => {
+          const deferred = document.getElementById(id);
+          if (deferred) {
+            deferred.scrollIntoView({ behavior: "smooth", block: "start" });
+          }
+        }, 100);
+        return () => clearTimeout(timer);
+      }
+
+      prevPathnameRef.current = pathname;
+      return;
+    }
+
+    // No hash — this is a clean page navigation. Reset to top immediately so
+    // there is no visible jump when the new page content renders.
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+    prevPathnameRef.current = pathname;
+  }, [pathname]);
+
+  // This component renders nothing — it is a behaviour-only side-effect hook.
+  return null;
+}


### PR DESCRIPTION
Fixes #169

### Summary
Route changes in the Next.js App Router did not reliably reset scroll position, and hash deep-links had no consistent behavior. This PR introduces a dedicated `ScrollRestorer` component that handles all three acceptance criteria cleanly.

### Changes

**`frontend/components/ScrollRestorer.tsx`** *(new)*
- Client component that subscribes to `usePathname()`.
- **Clean page navigation (no hash):** Calls `window.scrollTo({ top: 0, behavior: "instant" })` — resets scroll without any visible jump before content renders.
- **Hash / deep-link navigation:** Skips the scroll-reset and instead scrolls the target anchor into view with `behavior: "smooth"`. Includes a 100ms deferred fallback for streamed/async content that may not be in the DOM yet.
- **Same-page hash changes:** Fully delegated to browser-native anchor behavior, no interference.

**`frontend/app/layout.tsx`**
- Imports and mounts `<ScrollRestorer />` after `<Navigation />` so it is active for the entire session across all routes.

**`frontend/app/navigation.tsx`**
- Fixed the pre-existing bug: `useEffect` was used inside the component but never imported, causing a runtime `ReferenceError`. Added `useEffect` to the React import.

**`frontend/app/globals.css`**
- Added `html { scroll-behavior: smooth; }` to enable native smooth scrolling for anchor links.
- The existing `prefers-reduced-motion` rule already sets `scroll-behavior: auto !important` — so users with reduced-motion preferences are fully respected.

### Acceptance Criteria
- [x] Scroll resets on new pages where needed (clean navigations → `scrollTo top`)
- [x] Deep-link behavior preserved (hash URLs → smooth scroll to anchor)
- [x] No jumpy transitions (`behavior: "instant"` on reset, `behavior: "smooth"` on anchors, deferred fallback for async content)
