### PR TITLE
Improve formatting resilience, table semantics, and job count coverage.

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -832,6 +832,37 @@ mod test {
     }
 
     #[test]
+    fn job_count_increments_once_per_post_sequentially() {
+        let (env, client, _, user, _, native_token) = setup();
+        assert_eq!(client.get_job_count(), 0);
+
+        let first = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+        assert_eq!(first, 1);
+        assert_eq!(client.get_job_count(), 1);
+
+        let second = client.post_job(&user, &2_000_000i128, &hash(&env), &0u64, &native_token);
+        assert_eq!(second, 2);
+        assert_eq!(client.get_job_count(), 2);
+
+        let third = client.post_job(&user, &3_000_000i128, &hash(&env), &0u64, &native_token);
+        assert_eq!(third, 3);
+        assert_eq!(client.get_job_count(), 3);
+    }
+
+    #[test]
+    fn cancel_does_not_decrement_job_count() {
+        let (env, client, _, user, _, native_token) = setup();
+        let first = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+        let second = client.post_job(&user, &2_000_000i128, &hash(&env), &0u64, &native_token);
+        assert_eq!(client.get_job_count(), 2);
+
+        client.cancel_job(&user, &first);
+        assert_eq!(client.get_job_count(), 2);
+        assert_eq!(client.get_job(&first).status, JobStatus::Cancelled);
+        assert_eq!(client.get_job(&second).status, JobStatus::Open);
+    }
+
+    #[test]
     fn accept_and_approve_happy_path() {
         let (env, client, _, user, freelancer, native_token) = setup();
         let job_id = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);

--- a/frontend/__tests__/format.test.ts
+++ b/frontend/__tests__/format.test.ts
@@ -18,4 +18,10 @@ describe("toXlm", () => {
     expect(toXlm(10050000)).toBe("1.01");
     expect(toXlm(10049999)).toBe("1.00");
   });
+
+  it("formats very large amounts without scientific notation", () => {
+    const formatted = toXlm("1000000000000000000000");
+    expect(/[eE][+-]?\d+/.test(formatted)).toBe(false);
+    expect(/\d{2}$/.test(formatted)).toBe(true);
+  });
 });

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -10,6 +10,7 @@ import {
 import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
 import SectionCard from "@/components/SectionCard";
+import { toXlm } from "@/lib/format";
 import { useWallet } from "@/lib/wallet-context";
 import type { Job, JobStatus } from "@/lib/types";
 import { useEffect, useState, useCallback } from "react";
@@ -31,10 +32,6 @@ const STATUS_COLORS: Record<JobStatus, string> = {
   Cancelled: "bg-red-100 text-red-800",
   Disputed: "bg-orange-100 text-orange-800",
 };
-
-function toXlm(stroops: number) {
-  return (stroops / 10_000_000).toFixed(7);
-}
 
 export default function AdminPage() {
   const { wallet, connectWallet } = useWallet();
@@ -175,7 +172,12 @@ export default function AdminPage() {
       )}
 
       <SectionCard title="Platform Fees">
-        <p className="mt-2 text-3xl font-bold">{toXlm(fees)} XLM</p>
+        <p className="mt-2 flex items-baseline gap-2 text-3xl font-bold">
+          <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+            {toXlm(fees)}
+          </span>
+          <span className="shrink-0 text-base font-semibold">XLM</span>
+        </p>
         <p className="text-sm text-slate-500">Accrued platform fees (2.5%)</p>
         <button
           disabled={withdrawing || fees <= 0}
@@ -215,18 +217,18 @@ export default function AdminPage() {
             <table className="w-full text-left text-sm">
               <thead>
                 <tr className="border-b border-slate-200 text-xs text-slate-500">
-                  <th className="pb-2 pr-4">ID</th>
-                  <th className="pb-2 pr-4">Status</th>
-                  <th className="pb-2 pr-4">Client</th>
-                  <th className="pb-2 pr-4">Freelancer</th>
-                  <th className="pb-2 pr-4 text-right">Amount</th>
-                  <th className="pb-2 pr-4">Deadline</th>
+                  <th scope="col" className="pb-2 pr-4">ID</th>
+                  <th scope="col" className="pb-2 pr-4">Status</th>
+                  <th scope="col" className="pb-2 pr-4">Client</th>
+                  <th scope="col" className="pb-2 pr-4">Freelancer</th>
+                  <th scope="col" className="pb-2 pr-4 text-right">Amount</th>
+                  <th scope="col" className="pb-2 pr-4">Deadline</th>
                 </tr>
               </thead>
               <tbody>
                 {jobs.map(({ id, job }) => (
                   <tr key={id} className="border-b border-slate-100">
-                    <td className="py-2 pr-4 font-medium">#{id}</td>
+                    <th scope="row" className="py-2 pr-4 font-medium">#{id}</th>
                     <td className="py-2 pr-4">
                       <span
                         className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
@@ -241,7 +243,12 @@ export default function AdminPage() {
                       {job.freelancer ? `${job.freelancer.slice(0, 8)}...` : "-"}
                     </td>
                     <td className="py-2 pr-4 text-right">
-                      {(Number(job.amount) / 10_000_000).toFixed(2)} XLM
+                      <span className="inline-flex items-baseline justify-end gap-1">
+                        <span className="max-w-[10rem] overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+                          {toXlm(job.amount)}
+                        </span>
+                        <span className="shrink-0">XLM</span>
+                      </span>
                     </td>
                     <td className="py-2 pr-4 text-xs">
                       {job.deadline === "0"

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
 import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
 import SectionCard from "@/components/SectionCard";
+import { toXlm } from "@/lib/format";
 import { useWallet } from "@/lib/wallet-context";
 import type { Job, JobStatus } from "@/lib/types";
 import { useEffect, useState, useCallback } from "react";
@@ -40,10 +41,6 @@ const STATUS_COLORS: Record<JobStatus, string> = {
   Cancelled: "bg-red-100 text-red-800",
   Disputed: "bg-orange-100 text-orange-800",
 };
-
-function toXlm(stroops: string) {
-  return (Number(stroops) / 10_000_000).toFixed(2);
-}
 
 function formatDeadline(deadline: string) {
   if (deadline === "0") return "No deadline";
@@ -256,7 +253,12 @@ function JobCard({
         </span>
       </div>
       <div className="mt-2 space-y-1 text-sm text-slate-600">
-        <p>{toXlm(job.amount)} XLM</p>
+        <p className="flex items-baseline gap-1">
+          <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+            {toXlm(job.amount)}
+          </span>
+          <span className="shrink-0">XLM</span>
+        </p>
         <p>Deadline: {formatDeadline(job.deadline)}</p>
         {role === "client" && job.freelancer && (
           <p className="truncate">Freelancer: {job.freelancer}</p>

--- a/frontend/app/navigation.tsx
+++ b/frontend/app/navigation.tsx
@@ -39,13 +39,16 @@ export function Navigation() {
 
   return (
     <header className="border-b border-slate-200 bg-white">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4">
-        <Link href="/" className="text-lg font-semibold">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-4">
+        <Link href="/" className="shrink-0 text-lg font-semibold">
           StellarWork
         </Link>
 
-        <div className="hidden items-center gap-6 md:flex">
-          <nav aria-label="Main navigation" className="flex items-center gap-4 text-sm">
+        <div className="hidden min-w-0 items-center gap-4 lg:gap-6 md:flex">
+          <nav
+            aria-label="Main navigation"
+            className="flex flex-wrap items-center justify-end gap-x-4 gap-y-1 text-sm"
+          >
              {links.map(({ href, label }) => (
               <Link
                 key={href}
@@ -95,15 +98,15 @@ export function Navigation() {
 
       {menuOpen && (
         <div className="border-t border-slate-200 px-4 py-3 md:hidden">
-          <nav aria-label="Main navigation" className="flex flex-col gap-3 text-sm">
+          <nav aria-label="Main navigation" className="grid grid-cols-2 gap-3 text-sm">
              {links.map(({ href, label }) => (
               <Link
                 key={href}
                 href={href}
                 className={
                   isActive(href)
-                    ? "font-semibold text-slate-900"
-                    : "text-slate-600 hover:text-slate-900"
+                    ? "rounded-md bg-slate-100 px-2 py-1 font-semibold text-slate-900"
+                    : "rounded-md px-2 py-1 text-slate-600 hover:bg-slate-50 hover:text-slate-900"
                 }
                 onClick={() => setMenuOpen(false)}
               >

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,15 +5,12 @@ import LoadingState from "@/components/LoadingState";
 import EmptyState from "@/components/EmptyState";
 import SectionCard from "@/components/SectionCard";
 import { acceptJob, getJob, getJobCount } from "@/lib/contract";
+import { toXlm } from "@/lib/format";
 import { getExplorerTxUrl } from "@/lib/stellar";
 import type { Job } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
-function toXlm(stroops: string) {
-  return (Number(stroops) / 10_000_000).toFixed(2);
-}
 
 export default function HomePage() {
   const { wallet } = useWallet();
@@ -211,7 +208,12 @@ export default function HomePage() {
               <Link href={`/job/${id}`} className="block">
                 <h2 className="text-lg font-medium hover:underline">Job #{id}</h2>
               </Link>
-              <p className="mt-2 text-sm font-bold text-slate-700">{toXlm(job.amount)} XLM</p>
+              <p className="mt-2 flex items-baseline gap-1 text-sm font-bold text-slate-700">
+                <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+                  {toXlm(job.amount)}
+                </span>
+                <span className="shrink-0">XLM</span>
+              </p>
               <p className="mt-1 line-clamp-2 text-sm text-slate-700">
                 {getDescription(job.description_hash)}
               </p>

--- a/frontend/app/profile/[address]/profile-page-client.tsx
+++ b/frontend/app/profile/[address]/profile-page-client.tsx
@@ -2,6 +2,7 @@
 
 import ErrorBanner from "@/components/ErrorBanner";
 import { getJob, getJobCount } from "@/lib/contract";
+import { toXlm } from "@/lib/format";
 import type { Job, JobStatus } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
 import Link from "next/link";
@@ -27,10 +28,6 @@ const STATUS_COLORS: Record<JobStatus, string> = {
 
 function isValidStellarAddress(address: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(address);
-}
-
-function toXlm(stroops: number) {
-  return (stroops / 10_000_000).toFixed(2);
 }
 
 interface ProfileJob {
@@ -150,11 +147,21 @@ export default function ProfilePageClient({ address }: { address: string }) {
               <p className="text-xs text-slate-500">Jobs Completed</p>
             </div>
             <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">{toXlm(totalEarnedStroops)}</p>
+              <p className="flex items-baseline justify-center gap-1 text-2xl font-bold">
+                <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+                  {toXlm(totalEarnedStroops)}
+                </span>
+                <span className="shrink-0 text-xs font-semibold">XLM</span>
+              </p>
               <p className="text-xs text-slate-500">XLM Earned</p>
             </div>
             <div className="rounded-lg border border-slate-200 bg-white p-4 text-center">
-              <p className="text-2xl font-bold">{toXlm(totalSpentStroops)}</p>
+              <p className="flex items-baseline justify-center gap-1 text-2xl font-bold">
+                <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+                  {toXlm(totalSpentStroops)}
+                </span>
+                <span className="shrink-0 text-xs font-semibold">XLM</span>
+              </p>
               <p className="text-xs text-slate-500">XLM Spent</p>
             </div>
           </div>
@@ -170,21 +177,21 @@ export default function ProfilePageClient({ address }: { address: string }) {
                 <table className="w-full text-left text-sm">
                   <thead>
                     <tr className="border-b border-slate-200 text-xs text-slate-500">
-                      <th className="pb-2 pr-4">ID</th>
-                      <th className="pb-2 pr-4">Role</th>
-                      <th className="pb-2 pr-4">Status</th>
-                      <th className="pb-2 pr-4 text-right">Amount</th>
-                      <th className="pb-2 pr-4">Date</th>
+                      <th scope="col" className="pb-2 pr-4">ID</th>
+                      <th scope="col" className="pb-2 pr-4">Role</th>
+                      <th scope="col" className="pb-2 pr-4">Status</th>
+                      <th scope="col" className="pb-2 pr-4 text-right">Amount</th>
+                      <th scope="col" className="pb-2 pr-4">Date</th>
                     </tr>
                   </thead>
                   <tbody>
                     {jobs.map(({ id, job, role }) => (
                       <tr key={`${id}-${role}`} className="border-b border-slate-100">
-                        <td className="py-2 pr-4">
+                        <th scope="row" className="py-2 pr-4">
                           <Link href={`/job/${id}`} className="font-medium hover:underline">
                             #{id}
                           </Link>
-                        </td>
+                        </th>
                         <td className="py-2 pr-4 capitalize">{role}</td>
                         <td className="py-2 pr-4">
                           <span
@@ -194,7 +201,12 @@ export default function ProfilePageClient({ address }: { address: string }) {
                           </span>
                         </td>
                         <td className="py-2 pr-4 text-right">
-                          {toXlm(Number(job.amount))} XLM
+                          <span className="inline-flex items-baseline justify-end gap-1">
+                            <span className="max-w-[10rem] overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
+                              {toXlm(job.amount)}
+                            </span>
+                            <span className="shrink-0">XLM</span>
+                          </span>
                         </td>
                         <td className="py-2 pr-4 text-xs">
                           {new Date(Number(job.created_at) * 1000).toLocaleDateString()}

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -1,5 +1,25 @@
 export function toXlm(stroops: string | number | bigint): string {
-  const val = Number(stroops) / 10_000_000;
-  // Use a small epsilon to handle floating point precision issues for .005
-  return (Math.round((val + 0.00000001) * 100) / 100).toFixed(2);
+  const raw = typeof stroops === "bigint" ? stroops : BigInt(stroops);
+  const isNegative = raw < 0n;
+  const absolute = isNegative ? -raw : raw;
+
+  // 1 XLM = 10,000,000 stroops; convert to 2dp with integer rounding.
+  const roundedCents = (absolute * 100n + 5_000_000n) / 10_000_000n;
+  const whole = roundedCents / 100n;
+  const fraction = roundedCents % 100n;
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 0,
+  });
+  const wholeFormatted = formatter.format(whole);
+  const decimalSeparator =
+    new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })
+      .formatToParts(1.1)
+      .find((part) => part.type === "decimal")?.value ?? ".";
+
+  return `${isNegative ? "-" : ""}${wholeFormatted}${decimalSeparator}${fraction
+    .toString()
+    .padStart(2, "0")}`;
 }


### PR DESCRIPTION
## Summary

This PR improves UI robustness and contract test coverage in four areas:

- **Large amount rendering**
  - Centralizes XLM formatting in `frontend/lib/format.ts` using bigint-safe math to avoid floating-point issues with large values.
  - Uses locale-aware number formatting while preserving fixed 2-decimal output.
  - Updates amount displays to keep the `XLM` label visible and prevent overflow/truncation issues in constrained layouts.

- **Header responsiveness**
  - Refines `frontend/app/navigation.tsx` layout so links wrap cleanly on narrow widths.
  - Improves mobile navigation readability with clearer spacing/state styling.
  - Prevents overlap between brand, nav links, and wallet controls.

- **Semantic table markup**
  - Improves tabular semantics in admin/profile job tables by adding proper header and row scopes.
  - Ensures row/column relationships are explicit for accessibility and keyboard/screen-reader clarity.

- **Monotonic job count tests (contract)**
  - Adds sequential posting test coverage to verify `get_job_count` increments exactly once per `post_job`.
  - Adds cancellation coverage to verify `cancel_job` does **not** decrement total job count.

## Files Changed

- `frontend/lib/format.ts`
- `frontend/__tests__/format.test.ts`
- `frontend/app/navigation.tsx`
- `frontend/app/page.tsx`
- `frontend/app/dashboard/page.tsx`
- `frontend/app/admin/page.tsx`
- `frontend/app/profile/[address]/profile-page-client.tsx`
- `contracts/escrow/src/lib.rs`

## Why

These changes improve consistency and safety for large numeric displays, prevent responsive layout breakage in the header, strengthen semantic accessibility of tabular data, and lock in expected contract behavior for job counting over time.

## Testing

- Added/updated unit coverage for large number formatting behavior in:
  - `frontend/__tests__/format.test.ts`
- Added contract tests in:
  - `contracts/escrow/src/lib.rs`
    - `job_count_increments_once_per_post_sequentially`
    - `cancel_does_not_decrement_job_count`

### Suggested local verification

```bash
# frontend
cd frontend
npm install
npm test -- --run

# contract
cd ../contracts/escrow
cargo test



closes #166 
closes #171 
closes #180 
closes #179 