### PR TITLE
Implement accessibility, favorites, and cancelled-job analytics updates.

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -545,6 +545,25 @@ impl EscrowContract {
         count
     }
 
+    pub fn get_cancelled_jobs_count(e: Env) -> u64 {
+        let total = get_jobs_count(&e);
+        let mut count: u64 = 0;
+        let mut i: u64 = 1;
+        while i <= total {
+            if let Some(job) = e
+                .storage()
+                .persistent()
+                .get::<DataKey, Job>(&DataKey::Job(i))
+            {
+                if job.status == JobStatus::Cancelled {
+                    count += 1;
+                }
+            }
+            i += 1;
+        }
+        count
+    }
+
     pub fn get_jobs_by_status(e: Env, status: JobStatus) -> Vec<Job> {
         let total = get_jobs_count(&e);
         let mut jobs = Vec::new(&e);
@@ -1861,6 +1880,49 @@ mod test {
         client.submit_work(&freelancer, &job_id);
         client.approve_work(&user, &job_id);
         assert_eq!(client.get_open_jobs_count(), 0);
+    }
+
+    #[test]
+    fn get_cancelled_jobs_count_starts_at_zero() {
+        let (_, client, _, _, _, _) = setup();
+        assert_eq!(client.get_cancelled_jobs_count(), 0);
+    }
+
+    #[test]
+    fn get_cancelled_jobs_count_increments_on_cancel() {
+        let (env, client, _, user, _, native_token) = setup();
+        let job_id = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+        assert_eq!(client.get_cancelled_jobs_count(), 0);
+        client.cancel_job(&user, &job_id);
+        assert_eq!(client.get_cancelled_jobs_count(), 1);
+    }
+
+    #[test]
+    fn get_cancelled_jobs_count_tracks_multiple_cancel_paths() {
+        let (env, client, _, user, freelancer, native_token) = setup();
+        let direct_cancel =
+            client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+        let deadline_cancel = client.post_job(
+            &user,
+            &1_000_000i128,
+            &hash(&env),
+            &(1_710_000_000 + 300),
+            &native_token,
+        );
+        let completed = client.post_job(&user, &1_000_000i128, &hash(&env), &0u64, &native_token);
+
+        client.cancel_job(&user, &direct_cancel);
+        client.accept_job(&freelancer, &deadline_cancel);
+        env.ledger().with_mut(|li| {
+            li.timestamp = 1_710_000_500;
+        });
+        client.enforce_deadline(&user, &deadline_cancel);
+
+        client.accept_job(&freelancer, &completed);
+        client.submit_work(&freelancer, &completed);
+        client.approve_work(&user, &completed);
+
+        assert_eq!(client.get_cancelled_jobs_count(), 2);
     }
 
     fn expect_panic_with_contract_error<F>(f: F, code: u32)

--- a/frontend/__tests__/smoke.test.tsx
+++ b/frontend/__tests__/smoke.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "@/app/page";
 
@@ -100,5 +100,68 @@ describe("Home page render states", () => {
     );
     expect(screen.queryByRole("heading", { name: "Job #1" })).not.toBeInTheDocument();
     expect(screen.getByText("Accept Job")).toBeDisabled();
+  });
+
+  it("supports bookmarking jobs and favorites filter", async () => {
+    mockGetJobCount.mockResolvedValue(2);
+    mockGetJob
+      .mockResolvedValueOnce({
+        client: "GCLIENT",
+        freelancer: null,
+        amount: "25000000",
+        description_hash: "hash-two",
+        status: "Open",
+        created_at: "1710000000",
+        deadline: "0",
+        token: "GTOKEN",
+        revision_count: 0,
+      })
+      .mockResolvedValueOnce({
+        client: "GCLIENT",
+        freelancer: null,
+        amount: "10000000",
+        description_hash: "hash-one",
+        status: "Open",
+        created_at: "1710000001",
+        deadline: "0",
+        token: "GTOKEN",
+        revision_count: 0,
+      });
+
+    render(<HomePage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Job #2" })).toBeInTheDocument(),
+    );
+    const bookmarkButtons = screen.getAllByRole("button", { name: "Bookmark" });
+    fireEvent.click(bookmarkButtons[0]);
+    fireEvent.click(screen.getByLabelText("Favorites only"));
+    expect(screen.getByRole("heading", { name: "Job #2" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Job #1" })).not.toBeInTheDocument();
+  });
+
+  it("announces result counts without duplicate spam", async () => {
+    mockGetJobCount.mockResolvedValue(1);
+    mockGetJob.mockResolvedValue({
+      client: "GCLIENT",
+      freelancer: null,
+      amount: "25000000",
+      description_hash: "hash-two",
+      status: "Open",
+      created_at: "1710000000",
+      deadline: "0",
+      token: "GTOKEN",
+      revision_count: 0,
+    });
+
+    const { rerender } = render(<HomePage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("1 result shown")).toBeInTheDocument(),
+    );
+    rerender(<HomePage />);
+    await waitFor(() =>
+      expect(screen.getByText("1 result shown")).toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,6 +12,8 @@ import { useWallet } from "@/lib/wallet-context";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+const BOOKMARK_STORAGE_KEY = "stellarwork:bookmarked-jobs";
+
 export default function HomePage() {
   const { wallet } = useWallet();
   const [jobs, setJobs] = useState<Array<{ id: number; job: Job }>>([]);
@@ -23,11 +25,34 @@ export default function HomePage() {
   const [pageSize, setPageSize] = useState(10);
   const [totalJobs, setTotalJobs] = useState(0);
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
+  const [showBookmarkedOnly, setShowBookmarkedOnly] = useState(false);
+  const [bookmarkedIds, setBookmarkedIds] = useState<number[]>([]);
+  const [resultsAnnouncement, setResultsAnnouncement] = useState("");
+  const [lastAnnouncedSignature, setLastAnnouncedSignature] = useState("");
 
   const totalPages = useMemo(
     () => Math.max(1, Math.ceil(totalJobs / pageSize)),
     [pageSize, totalJobs],
   );
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(BOOKMARK_STORAGE_KEY);
+      if (!stored) return;
+      const parsed = JSON.parse(stored) as unknown;
+      if (!Array.isArray(parsed)) return;
+      const validIds = parsed
+        .map((entry) => Number(entry))
+        .filter((value) => Number.isInteger(value) && value > 0);
+      setBookmarkedIds(validIds);
+    } catch {
+      // Ignore malformed local storage data and use empty bookmarks.
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(BOOKMARK_STORAGE_KEY, JSON.stringify(bookmarkedIds));
+  }, [bookmarkedIds]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -88,6 +113,24 @@ export default function HomePage() {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  const visibleJobs = useMemo(
+    () =>
+      showBookmarkedOnly
+        ? jobs.filter(({ id }) => bookmarkedIds.includes(id))
+        : jobs,
+    [bookmarkedIds, jobs, showBookmarkedOnly],
+  );
+
+  useEffect(() => {
+    if (loading) return;
+    const currentSignature = `${showBookmarkedOnly}:${visibleJobs.map(({ id }) => id).join(",")}`;
+    if (currentSignature === lastAnnouncedSignature) return;
+    setResultsAnnouncement(
+      `${visibleJobs.length} ${visibleJobs.length === 1 ? "result" : "results"} shown`,
+    );
+    setLastAnnouncedSignature(currentSignature);
+  }, [lastAnnouncedSignature, loading, showBookmarkedOnly, visibleJobs]);
 
   const [copiedHash, setCopiedHash] = useState<string | null>(null);
 
@@ -154,6 +197,9 @@ export default function HomePage() {
           Refreshing jobs…
         </p>
       )}
+      <p role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {resultsAnnouncement}
+      </p>
 
       {latestTxHash && (
         <p className="text-sm text-slate-600">
@@ -169,10 +215,14 @@ export default function HomePage() {
         </p>
       )}
 
-      {!loading && jobs.length === 0 && !error && (
+      {!loading && visibleJobs.length === 0 && !error && (
         <EmptyState
-          title="No open jobs found"
-          description="New jobs will appear here as clients post them."
+          title={showBookmarkedOnly ? "No favorites found" : "No open jobs found"}
+          description={
+            showBookmarkedOnly
+              ? "Bookmark jobs to quickly find them here."
+              : "New jobs will appear here as clients post them."
+          }
         />
       )}
 
@@ -180,29 +230,45 @@ export default function HomePage() {
         title="Jobs Display"
         description="Default sort is newest first."
       >
-        <div className="flex items-center gap-2 text-sm text-slate-600">
-          <label htmlFor="jobs-sort-order">Sort:</label>
-          <select
-            id="jobs-sort-order"
-            value={sortOrder}
-            onChange={(event) => {
-              setSortOrder(event.target.value as "newest" | "oldest");
-              setPage(1);
-            }}
-            className="rounded-md border border-slate-300 bg-white px-2 py-1"
-            disabled={loading}
-          >
-            <option value="newest">Newest first</option>
-            <option value="oldest">Oldest first</option>
-          </select>
-        </div>
+        <fieldset className="space-y-3 rounded-md border border-slate-200 p-3">
+          <legend className="px-1 text-sm font-medium text-slate-700">
+            Sort and filter job results
+          </legend>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+            <label htmlFor="jobs-sort-order">Sort:</label>
+            <select
+              id="jobs-sort-order"
+              value={sortOrder}
+              onChange={(event) => {
+                setSortOrder(event.target.value as "newest" | "oldest");
+                setPage(1);
+              }}
+              className="rounded-md border border-slate-300 bg-white px-2 py-1"
+              disabled={loading}
+            >
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+            </select>
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={showBookmarkedOnly}
+                onChange={(event) => {
+                  setShowBookmarkedOnly(event.target.checked);
+                }}
+                className="h-4 w-4 rounded border-slate-300"
+              />
+              Favorites only
+            </label>
+          </div>
+        </fieldset>
       </SectionCard>
 
       <ul
         className="grid list-none gap-4 md:grid-cols-2"
         aria-label="Open jobs"
       >
-        {jobs.map(({ id, job }) => (
+        {visibleJobs.map(({ id, job }) => (
           <li key={id}>
             <article className="h-full rounded-lg border border-slate-200 bg-white p-4 transition-shadow hover:shadow-md">
               <Link href={`/job/${id}`} className="block">
@@ -265,6 +331,20 @@ export default function HomePage() {
                 >
                   {actionLoading === id ? "Processing..." : "Accept Job"}
                 </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={() => {
+                    setBookmarkedIds((prev) =>
+                      prev.includes(id)
+                        ? prev.filter((value) => value !== id)
+                        : [...prev, id],
+                    );
+                  }}
+                  aria-pressed={bookmarkedIds.includes(id)}
+                >
+                  {bookmarkedIds.includes(id) ? "Bookmarked" : "Bookmark"}
+                </button>
               </div>
               {!wallet && (
                 <p className="mt-2 text-xs text-amber-700">
@@ -278,7 +358,8 @@ export default function HomePage() {
 
       {totalJobs > 0 && (
         <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2 text-sm text-slate-600">
+          <fieldset className="flex items-center gap-2 text-sm text-slate-600">
+            <legend className="sr-only">Pagination settings</legend>
             <label htmlFor="jobs-page-size">Page size:</label>
             <select
               id="jobs-page-size"
@@ -296,7 +377,7 @@ export default function HomePage() {
                 </option>
               ))}
             </select>
-          </div>
+          </fieldset>
 
           <div className="flex items-center gap-2">
             <button


### PR DESCRIPTION
## Summary

This PR delivers four open-source contributions in one branch:

- Added polite, non-spammy result-count announcements after list refresh/filter changes on the jobs page.
- Exposed cancelled jobs analytics via a new contract view method: `get_cancelled_jobs_count`.
- Implemented local job bookmarking with per-job toggle and a `Favorites only` filter.
- Improved accessibility semantics by grouping related controls with descriptive `fieldset`/`legend`.

## Changes by Contribution

### 1) Announce result counts after list refresh/filtering

- Added a polite live region on `frontend/app/page.tsx` to announce current visible result counts.
- Announcements trigger when result visibility changes (refresh/filter) and avoid repeated identical announcements.
- Announcement text uses singular/plural correctly (`1 result shown` / `N results shown`).

### 2) Expose cancelled jobs count for analytics

- Added `get_cancelled_jobs_count(e: Env) -> u64` to `contracts/escrow/src/lib.rs`.
- Method iterates through stored jobs and counts entries with `JobStatus::Cancelled`.
- Added coverage for:
  - initial zero state
  - increment on direct cancel
  - mixed lifecycle paths including deadline enforcement and completed jobs

### 3) Allow local bookmarking of jobs for quick access

- Added bookmark toggle button per job card (`Bookmark` / `Bookmarked`).
- Added `Favorites only` filter to show bookmarked jobs.
- Bookmarks persist locally in browser storage under:
  - `stellarwork:bookmarked-jobs`

### 4) Group related inputs with fieldset/legend semantics

- Wrapped sort + favorites controls in a semantic `fieldset` with descriptive `legend`.
- Wrapped pagination page-size control in a semantic `fieldset` with screen-reader-friendly legend.
- Improves navigation and context for assistive technologies.

## Files Changed

- `frontend/app/page.tsx`
- `frontend/__tests__/smoke.test.tsx`
- `contracts/escrow/src/lib.rs`

## Testing

### Frontend

- Added/updated tests in `frontend/__tests__/smoke.test.tsx` for:
  - bookmarking + favorites filter behavior
  - result-count announcement behavior

### Contract

- Added tests in `contracts/escrow/src/lib.rs` for:
  - `get_cancelled_jobs_count_starts_at_zero`
  - `get_cancelled_jobs_count_increments_on_cancel`
  - `get_cancelled_jobs_count_tracks_multiple_cancel_paths`

## Notes

- This PR intentionally includes only implementation changes required for the four assigned contributions.
- No unnecessary files were added.



closes #205 
closes #203 
closes #206 
closes #208 
