### PR TITLE
docs: add contributor guides, glossary, and testing matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for contributing.
 
+New contributors: start with the [onboarding checklist](docs/contributor-onboarding-checklist.md) and the [docs index](docs/README.md).
+
 ## Branching
 
 - Fork and create branches as `feature/<issue-number>-<short-description>`.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ soroban contract invoke \
 
 For a command-only deployment reference, see `docs/testnet-deployment-guide.md`.
 
+For the full documentation index, see [docs/README.md](docs/README.md).
+
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# StellarWork Documentation
+
+Index of project documentation. Start with the [root README](../README.md) for setup, then use the guides below by topic.
+
+## Getting Started
+
+| Document | Description |
+|----------|-------------|
+| [contributor-onboarding-checklist.md](./contributor-onboarding-checklist.md) | First-time contributor setup and first PR checklist |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Branching, PR requirements, labels, and pre-commit hooks |
+| [glossary.md](./glossary.md) | Contract and frontend terminology |
+
+## Architecture & Contracts
+
+| Document | Description |
+|----------|-------------|
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | System components, data split, wallet integration, lifecycle |
+| [CONTRACT.md](./CONTRACT.md) | Escrow contract overview and data model |
+| [contract-reference.md](./contract-reference.md) | Method-level contract reference |
+| [testnet-deployment-guide.md](./testnet-deployment-guide.md) | Deploy escrow to Stellar testnet |
+
+## Operations & Quality
+
+| Document | Description |
+|----------|-------------|
+| [testing-matrix.md](./testing-matrix.md) | Unit, integration, and E2E test coverage and commands |
+| [release-checklist.md](./release-checklist.md) | Pre-release verification steps |
+| [release-notes-guide.md](./release-notes-guide.md) | How to write release notes entries |
+| [environments.md](./environments.md) | Environment variables and target networks |
+| [troubleshooting.md](./troubleshooting.md) | Common errors and fixes |
+| [TRIAGE.md](./TRIAGE.md) | Issue labels and triage process |
+
+## Maintenance
+
+| Document | Description |
+|----------|-------------|
+| [production-escalation.md](./production-escalation.md) | Production incident response |
+| [maintenance-window-announcement-template.md](./maintenance-window-announcement-template.md) | Planned downtime announcement template |
+| [storage-key-migration-note.md](./storage-key-migration-note.md) | Storage key migration notes |
+| [heading-hierarchy-audit.md](./heading-hierarchy-audit.md) | Documentation heading structure audit |

--- a/docs/contributor-onboarding-checklist.md
+++ b/docs/contributor-onboarding-checklist.md
@@ -1,0 +1,78 @@
+# Contributor Onboarding Checklist
+
+Use this checklist for your first contribution to StellarWork. For ongoing rules, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Before You Start
+
+- [ ] Read the [README](../README.md) for project overview and local setup options.
+- [ ] Skim [ARCHITECTURE.md](./ARCHITECTURE.md) to understand on-chain vs off-chain data and the job lifecycle.
+- [ ] Review open issues labeled [`good first issue`](https://github.com/anumukul/Stellar-work-/labels/good%20first%20issue) or pick an issue you can reproduce.
+- [ ] Fork the repository and clone your fork locally.
+
+## Local Setup
+
+### Contract (Rust / Soroban)
+
+- [ ] Install the [Soroban CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup) and Rust toolchain.
+- [ ] Run contract tests:
+  ```bash
+  cd contracts/escrow
+  cargo test
+  ```
+- [ ] Confirm the contract builds:
+  ```bash
+  cd contracts/escrow
+  soroban contract build
+  ```
+
+### Frontend (Next.js)
+
+Choose one setup path:
+
+**Docker (recommended)**
+
+- [ ] Copy environment file and start the stack:
+  ```bash
+  cd frontend
+  cp .env.example .env.local
+  cd ..
+  docker compose up
+  ```
+- [ ] Open [http://localhost:3000](http://localhost:3000).
+
+**Manual**
+
+- [ ] Install dependencies and configure environment:
+  ```bash
+  cd frontend
+  cp .env.example .env.local
+  npm install
+  npm run dev
+  ```
+- [ ] Set `NEXT_PUBLIC_CONTRACT_ID` in `.env.local` (see [environments.md](./environments.md) and [testnet-deployment-guide.md](./testnet-deployment-guide.md)).
+
+### Optional Quality Tools
+
+- [ ] Set up [pre-commit hooks](../CONTRIBUTING.md#pre-commit-hooks-optional) if you want automatic lint/format checks before commits.
+
+## Before Your First PR
+
+- [ ] Create a branch named `feature/<issue-number>-<short-description>` (see [CONTRIBUTING.md](../CONTRIBUTING.md#branching)).
+- [ ] Keep changes scoped to the linked issue.
+- [ ] Run the checks relevant to your change:
+  - Contract: `cargo test`, `cargo fmt --all -- --check`, `soroban contract build` in `contracts/escrow`
+  - Frontend: `npm run lint`, `npm test`, and `npm run build` in `frontend` when you touch UI or client code
+- [ ] Reference the issue number in your PR description and explain key design choices.
+- [ ] Add screenshots or short clips for UI changes.
+- [ ] Confirm CI expectations in the [testing matrix](./testing-matrix.md).
+
+## Helpful References
+
+| Topic | Document |
+|-------|----------|
+| Contribution rules | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Contract API | [contract-reference.md](./contract-reference.md) |
+| Environment variables | [environments.md](./environments.md) |
+| Issue labels & triage | [TRIAGE.md](./TRIAGE.md) |
+| Terminology | [glossary.md](./glossary.md) |
+| Troubleshooting | [troubleshooting.md](./troubleshooting.md) |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,43 @@
+# Glossary
+
+Concise definitions for contract and frontend terminology used across StellarWork docs and code.
+
+## Contract Terms
+
+| Term | Definition |
+|------|------------|
+| **Escrow** | Soroban smart contract (`contracts/escrow`) that holds job payments and releases them based on on-chain job status. |
+| **Job** | On-chain record with client, optional freelancer, amount, status, deadlines, and metadata hash. See [contract-reference.md](./contract-reference.md). |
+| **Job status** | Lifecycle state: `Open`, `InProgress`, `SubmittedForReview`, `Completed`, `Cancelled`, or `Disputed`. |
+| **Client** | Stellar account that posts and funds a job; may approve, reject, cancel, or raise disputes. |
+| **Freelancer** | Stellar account that accepts a job, submits work, and receives payout on approval. |
+| **desc_hash** | SHA-256 hash (`BytesN<32>`) of the job description stored on-chain; all-zero hash is rejected. |
+| **description_payload_len** | Byte length of the off-chain description payload; enforced at `post_job` against contract limits. |
+| **deadline** | Unix epoch **seconds** after which in-progress jobs may be cancelled via `enforce_deadline`; `0` means no deadline. |
+| **Platform fee** | Percentage (default 2.5%, 250 bps) retained by the contract on successful payout; tracked per token. |
+| **Native token** | Default Stellar token contract configured at contract `initialize`. |
+| **Dispute** | Escalation path when client or freelancer calls `raise_dispute`; admin resolves via `resolve_dispute`. |
+| **Revision** | Client rejection of submitted work (`reject_work`); returns job to `InProgress` until revision limit (3) is reached. |
+| **Soroban** | Stellar smart contract platform; StellarWork contracts compile to wasm for Soroban deployment. |
+
+## Frontend Terms
+
+| Term | Definition |
+|------|------------|
+| **Freighter** | Browser wallet extension used to connect accounts and sign transactions (`@stellar/freighter-api`). |
+| **Contract ID** | Deployed escrow contract address; set as `NEXT_PUBLIC_CONTRACT_ID` in `frontend/.env.local`. |
+| **Off-chain metadata** | Job titles, descriptions, and profile details stored outside the contract (e.g. browser `localStorage`), matched to on-chain job IDs. |
+| **Horizon / Soroban RPC** | Network endpoints the frontend uses to submit transactions and read contract state (see [environments.md](./environments.md)). |
+| **scVal** | Soroban typed value encoding used when building contract invocation arguments in `frontend/lib/stellar.ts`. |
+| **App Router** | Next.js routing under `frontend/app/` (`/`, `/post-job`, `/job/[id]`, `/dashboard`, etc.). |
+| **Wallet context** | React context wrapping Freighter connection state and account address for pages and actions. |
+
+## Shared Concepts
+
+| Term | Definition |
+|------|------------|
+| **Testnet** | Default Stellar network for development; uses test lumens and testnet contract deployments. |
+| **Integration boundary** | Split between authoritative on-chain job/financial state and off-chain descriptive content merged in the UI. |
+| **Lifecycle action** | User operation that maps to a contract method (post, accept, submit, approve, cancel, dispute). |
+
+For method-level detail, see [contract-reference.md](./contract-reference.md) and [ARCHITECTURE.md](./ARCHITECTURE.md).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,7 +23,7 @@ Use this checklist before creating a release tag.
 
 ## Release
 
-- Update release notes/changelog for user-facing and contract changes
+- Update release notes/changelog for user-facing and contract changes (see [release-notes-guide.md](./release-notes-guide.md))
 - Bump version in the release metadata used by maintainers
 - Create and push a version tag (example: `v1.2.0`)
 - Open GitHub release for the tag and attach notes/artifacts as needed

--- a/docs/release-notes-guide.md
+++ b/docs/release-notes-guide.md
@@ -1,0 +1,107 @@
+# Release Notes Writing Guide
+
+Use this guide when drafting GitHub release notes or changelog entries. For the pre-release verification steps, see [release-checklist.md](./release-checklist.md).
+
+## Template Structure
+
+Each release should include these sections in order. Omit a section only when nothing applies.
+
+```markdown
+## Summary
+One or two sentences describing the release theme.
+
+## Added
+- New user-facing features or contract capabilities.
+
+## Changed
+- Behavior changes that are not breaking fixes.
+
+## Fixed
+- Bug fixes with enough context to understand impact.
+
+## Contract
+- Deployment notes: wasm changes, new init requirements, migration steps.
+
+## Breaking Changes
+- Explicit list of changes that require action from integrators or operators.
+
+## Contributors
+- @username for notable contributions (optional).
+```
+
+## Example Entries
+
+### Added
+
+```markdown
+## Added
+- Dispute overview page at `/disputes` for jobs in `Disputed` status.
+- `get_open_jobs_count` read method for dashboard metrics.
+```
+
+### Changed
+
+```markdown
+## Changed
+- Post-job form now validates description length against the on-chain payload limit before submission.
+- Platform fee display uses 2.5% (250 bps) consistently across job detail and admin views.
+```
+
+### Fixed
+
+```markdown
+## Fixed
+- Job detail page no longer shows approve actions when status is `Cancelled`.
+- Contract rejects `post_job` when `desc_hash` is all zeros (#142).
+```
+
+### Contract
+
+```markdown
+## Contract
+- Redeploy required: escrow wasm updated for deadline enforcement on `accept_job`.
+- After deploy, run `initialize` only on fresh instances; existing deployments keep prior admin and token config.
+```
+
+### Breaking Changes
+
+```markdown
+## Breaking Changes
+- `NEXT_PUBLIC_SOROBAN_RPC` replaces the unused `NEXT_PUBLIC_SOROBAN_RPC_URL` env var; update `.env.local` before upgrading frontend.
+- `post_job` signature now requires `description_payload_len`; update custom integrators.
+```
+
+## Scope Rules
+
+**Include in release notes**
+
+- User-visible frontend behavior (pages, flows, errors, wallet prompts).
+- Contract method additions, signature changes, or state machine changes.
+- Required operator actions (redeploy, env var changes, re-initialization).
+- Security fixes and data-integrity fixes (describe impact, not exploit details).
+- Notable performance or reliability improvements users or integrators would notice.
+
+**Keep brief or omit**
+
+- Internal refactors with no external behavior change.
+- Dependency bumps that do not change runtime behavior.
+- CI, lint, or test-only changes (unless they unblock releases).
+- Documentation-only updates (link to docs in Summary if helpful).
+
+**Breaking change criteria**
+
+Mark a change as breaking when:
+
+- A contract method signature or storage layout requires redeploy or migration.
+- Frontend env vars are renamed, removed, or change semantics.
+- Job status transitions or authorization rules change in a way that breaks existing clients.
+- Default network or contract ID assumptions change for packaged deployments.
+
+When in doubt, prefer calling out a change explicitly rather than burying it under **Changed**.
+
+## Writing Tips
+
+- Lead with the outcome (“Freelancers can extend job TTL”) not the implementation (“Added `extend_job_ttl` helper”).
+- Link related issues or PRs: `(#123)`.
+- Use present tense for capabilities (“Adds”, “Fixes”) or past tense consistently within a release—do not mix both in the same section.
+- For contract releases, always state whether redeploy is required and whether existing job state remains compatible.

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -1,0 +1,102 @@
+# Testing Matrix
+
+Summary of test suites in StellarWork: what each layer covers, how to run it, and who is expected to maintain it.
+
+## Overview
+
+| Layer | Location | Command | CI workflow | Primary owner |
+|-------|----------|---------|-------------|---------------|
+| Contract unit / integration | `contracts/escrow/src/lib.rs` (`mod test`) | `cd contracts/escrow && cargo test` | [Contract CI](../.github/workflows/contract.yml) | Contract contributors |
+| Frontend unit | `frontend/__tests__/` | `cd frontend && npm test` | Not gated in CI today* | Frontend contributors |
+| Frontend E2E | `frontend/e2e/` | `cd frontend && npm run test:e2e` | Not gated in CI today* | Frontend contributors |
+
+\* Frontend CI currently runs lint and production build only. Contributors should still run unit and E2E tests locally before opening PRs that touch frontend behavior (see [CONTRIBUTING.md](../CONTRIBUTING.md) and [release-checklist.md](./release-checklist.md)).
+
+## Contract Tests
+
+**Scope:** Soroban escrow logic—job lifecycle, fees, disputes, deadlines, authorization, and invariants—using the Soroban test environment and snapshot fixtures under `contracts/escrow/test_snapshots/`.
+
+**Covers**
+
+- Happy paths: post → accept → submit → approve
+- Invalid transitions and error codes
+- Fee accounting and admin operations
+- Dispute raise/resolve flows
+- Property-style and matrix tests for status transitions
+
+**Commands**
+
+```bash
+cd contracts/escrow
+cargo test                    # run all contract tests
+cargo fmt --all -- --check    # formatting (also run in CI)
+soroban contract build        # wasm build (also run in CI)
+```
+
+**Expectation:** Any change to `contracts/escrow/` must include updated or new tests. CI blocks merge on fmt, build, and test failures.
+
+## Frontend Unit Tests
+
+**Scope:** Isolated tests for utilities, React components, and contract helper logic with mocked wallet/RPC dependencies (Vitest + Testing Library).
+
+**Covers**
+
+| Area | Example files |
+|------|----------------|
+| Contract helpers | `__tests__/contract.test.ts` |
+| Formatting / IDs | `__tests__/format.test.ts`, `__tests__/recent-ids.test.ts` |
+| Wallet context | `__tests__/wallet-context.test.tsx` |
+| Page components | `__tests__/job-detail-actions.test.tsx`, `__tests__/disputes-page.test.tsx` |
+| UI primitives | `__tests__/toast-provider.test.tsx`, `__tests__/smoke.test.tsx` |
+
+**Commands**
+
+```bash
+cd frontend
+npm test                 # single run (CI-friendly)
+npm run test:watch       # watch mode during development
+npm run lint             # ESLint
+npm run typecheck        # TypeScript
+npm run build            # production build (run in CI)
+```
+
+**Expectation:** Add or update unit tests when changing logic in `frontend/lib/` or component behavior. Mock external Stellar calls; do not hit testnet in unit tests.
+
+## Frontend E2E Tests
+
+**Scope:** Browser-level flows against the running Next.js app (Playwright)—navigation, page load, and critical user journeys without full on-chain signing.
+
+**Covers**
+
+| Spec | Focus |
+|------|-------|
+| `e2e/home.spec.ts` | Home page load, navigation to post job and dashboard |
+| `e2e/post-job.spec.ts` | Post job page rendering and form presence |
+| `e2e/job-detail.spec.ts` | Job detail route and UI elements |
+| `e2e/navigation.spec.ts` | Cross-page navigation consistency |
+
+**Commands**
+
+```bash
+cd frontend
+npm run dev              # start app in a separate terminal (default :3000)
+npm run test:e2e         # headless Playwright run
+npm run test:e2e -- --headed   # visible browser (debugging)
+```
+
+**Expectation:** Update E2E specs when routes, primary headings, or navigation labels change. E2E tests assume the dev server is reachable at the Playwright base URL (see `frontend/playwright.config.ts` if present).
+
+## What Is Not Covered Here
+
+- Manual testnet deployment verification (see [testnet-deployment-guide.md](./testnet-deployment-guide.md))
+- Pre-commit hook runs (optional; see [CONTRIBUTING.md](../CONTRIBUTING.md#pre-commit-hooks-optional))
+- Full wallet-signed transaction flows on public networks (manual QA with Freighter on testnet)
+
+## Quick Pre-PR Matrix
+
+| You changed… | Run at minimum |
+|--------------|----------------|
+| `contracts/escrow/` | `cargo test`, `cargo fmt --all -- --check`, `soroban contract build` |
+| `frontend/lib/` or components | `npm test`, `npm run lint`, `npm run build` |
+| Routes or primary UI flows | Above + `npm run test:e2e` |
+| Docs only | No test runs required; verify links manually |


### PR DESCRIPTION
## Summary

Adds contributor and reference documentation for four related docs issues:

- **#229 [DOC-15]** — First-time contributor onboarding checklist (setup + first PR steps)
- **#234 [DOC-16]** — Project glossary for contract and frontend terminology
- **#239 [DOC-17]** — Testing matrix summarizing unit, contract, and E2E coverage
- **#247 [DOC-19]** — Release notes writing guide with template, examples, and scope rules

Introduces `docs/README.md` as a documentation index and links the new material from `CONTRIBUTING.md`, the root `README.md`, and `docs/release-checklist.md`.

## Changes

| File | Purpose |
|------|---------|
| `docs/contributor-onboarding-checklist.md` | Step-by-step checklist for fork, local setup, checks, and opening a first PR |
| `docs/glossary.md` | Concise definitions for escrow, job lifecycle, wallet, and frontend concepts |
| `docs/testing-matrix.md` | Matrix of contract, frontend unit, and Playwright E2E suites with commands and ownership |
| `docs/release-notes-guide.md` | Release notes template, example entries, and inclusion/exclusion scope rules |
| `docs/README.md` | Central index linking all project documentation |
| `CONTRIBUTING.md` | Link to onboarding checklist and docs index |
| `README.md` | Link to docs index |
| `docs/release-checklist.md` | Link to release notes guide |

## Test plan

- [ ] Open `docs/README.md` and confirm all links resolve
- [ ] Review `docs/contributor-onboarding-checklist.md` against current setup steps in root `README.md`
- [ ] Verify glossary terms match `docs/contract-reference.md` and `docs/ARCHITECTURE.md`
- [ ] Confirm testing matrix commands match `frontend/package.json` and `contracts/escrow` CI workflow
- [ ] Skim release notes examples for consistency with `docs/release-checklist.md`

Closes #229
Closes #234
Closes #239
Closes #247