### PR TITLE
feat: shared job UI states and retries

### DIFF
--- a/frontend/__tests__/profile-fallback.test.tsx
+++ b/frontend/__tests__/profile-fallback.test.tsx
@@ -39,10 +39,14 @@ describe("Profile Route Fallback Handling", () => {
 
     // Check for invalid address message
     expect(screen.getByText("Invalid Address")).toBeInTheDocument();
-    expect(screen.getByText(`"${invalidAddress}" is not a valid Stellar address.`)).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`${invalidAddress}.*valid Stellar address`)),
+    ).toBeInTheDocument();
     
     // Check for helpful hint
-    expect(screen.getByText(/Stellar addresses start with "G"/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Stellar addresses start with .*G.*56 characters long/),
+    ).toBeInTheDocument();
 
     // Check for back navigation
     const backLink = screen.getByRole("link", { name: /Back to Home/ });

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/contract";
 import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
+import StatusPill from "@/components/StatusPill";
 import SectionCard from "@/components/SectionCard";
 import { formatDeadline, toXlm } from "@/lib/format";
 import { useWallet } from "@/lib/wallet-context";
@@ -22,15 +23,6 @@ const STATUS_LABELS: Record<JobStatus, string> = {
   Completed: "Completed",
   Cancelled: "Cancelled",
   Disputed: "Disputed",
-};
-
-const STATUS_COLORS: Record<JobStatus, string> = {
-  Open: "bg-blue-100 text-blue-800",
-  InProgress: "bg-yellow-100 text-yellow-800",
-  SubmittedForReview: "bg-purple-100 text-purple-800",
-  Completed: "bg-green-100 text-green-800",
-  Cancelled: "bg-red-100 text-red-800",
-  Disputed: "bg-orange-100 text-orange-800",
 };
 
 export default function AdminPage() {
@@ -164,7 +156,13 @@ export default function AdminPage() {
     <section className="space-y-6">
       <h1 className="text-2xl font-semibold">Admin Panel</h1>
 
-      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
+      {error && (
+        <ErrorBanner
+          message={error}
+          onDismiss={() => setError(null)}
+          onRetry={() => void fetchAdminData(wallet)}
+        />
+      )}
       {successMessage && (
         <p className="rounded-md bg-green-100 p-3 text-sm text-green-700">
           {successMessage}
@@ -233,11 +231,7 @@ export default function AdminPage() {
                   <tr key={id} className="border-b border-slate-100">
                     <th scope="row" className="py-2 pr-4 font-medium">#{id}</th>
                     <td className="py-2 pr-4">
-                      <span
-                        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
-                      >
-                        {STATUS_LABELS[job.status]}
-                      </span>
+                      <StatusPill status={job.status} />
                     </td>
                     <td className="py-2 pr-4 font-mono text-xs">
                       {job.client.slice(0, 8)}...

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -12,8 +12,11 @@ import {
 import CancelJobConfirmModal from "@/components/CancelJobConfirmModal";
 import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
+import InfoTooltip from "@/components/InfoTooltip";
 import JobCardSkeleton from "@/components/JobCardSkeleton";
+import NoResultsState from "@/components/NoResultsState";
 import SectionCard from "@/components/SectionCard";
+import StatusPill from "@/components/StatusPill";
 import { useToast } from "@/components/ToastProvider";
 import { formatDeadline, toXlm } from "@/lib/format";
 import { useWallet } from "@/lib/wallet-context";
@@ -35,15 +38,6 @@ const STATUS_LABELS: Record<JobStatus, string> = {
   Completed: "Completed",
   Cancelled: "Cancelled",
   Disputed: "Disputed",
-};
-
-const STATUS_COLORS: Record<JobStatus, string> = {
-  Open: "bg-blue-100 text-blue-800",
-  InProgress: "bg-yellow-100 text-yellow-800",
-  SubmittedForReview: "bg-purple-100 text-purple-800",
-  Completed: "bg-green-100 text-green-800",
-  Cancelled: "bg-red-100 text-red-800",
-  Disputed: "bg-orange-100 text-orange-800",
 };
 
 export default function DashboardPage() {
@@ -197,6 +191,13 @@ export default function DashboardPage() {
         role="toolbar"
         aria-label="Filter jobs by status"
       >
+        <div className="mr-1 flex items-center gap-2 text-sm text-slate-600">
+          <span>Filter:</span>
+          <InfoTooltip
+            label="Filter jobs by status help"
+            content="Use the status chips to narrow your job history. Arrow keys move between filters."
+          />
+        </div>
         {filterOptions.map((s, index) => (
           <button
             key={s}
@@ -216,7 +217,13 @@ export default function DashboardPage() {
         ))}
       </div>
 
-      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
+      {error && (
+        <ErrorBanner
+          message={error}
+          onDismiss={() => setError(null)}
+          onRetry={() => void fetchJobs()}
+        />
+      )}
       {loading && (
         <div className="grid gap-4 md:grid-cols-2" aria-label="Loading jobs">
           {Array.from({ length: 4 }).map((_, index) => (
@@ -230,22 +237,28 @@ export default function DashboardPage() {
           <JobSection
             title="Posted Jobs"
             subtitle="Jobs you created as a client"
+            allJobs={postedJobs}
             jobs={filteredPosted}
+            filterActive={statusFilter !== "All"}
             wallet={wallet}
             role="client"
             actionLoading={actionLoading}
             onAction={handleAction}
             onRequestCancel={setPendingCancelJobId}
+            onClearFilter={() => setStatusFilter("All")}
           />
           <JobSection
             title="Accepted Jobs"
             subtitle="Jobs you accepted as a freelancer"
+            allJobs={acceptedJobs}
             jobs={filteredAccepted}
+            filterActive={statusFilter !== "All"}
             wallet={wallet}
             role="freelancer"
             actionLoading={actionLoading}
             onAction={handleAction}
             onRequestCancel={setPendingCancelJobId}
+            onClearFilter={() => setStatusFilter("All")}
           />
         </>
       )}
@@ -267,31 +280,46 @@ export default function DashboardPage() {
 function JobSection({
   title,
   subtitle,
+  allJobs,
   jobs,
+  filterActive,
   wallet,
   role,
   actionLoading,
   onAction,
   onRequestCancel,
+  onClearFilter,
 }: {
   title: string;
   subtitle: string;
+  allJobs: Array<{ id: number; job: Job }>;
   jobs: Array<{ id: number; job: Job }>;
+  filterActive: boolean;
   wallet: string;
   role: "client" | "freelancer";
   actionLoading: number | null;
   onAction: (fn: () => Promise<unknown>, jobId: number) => Promise<void>;
   onRequestCancel: (jobId: number) => void;
+  onClearFilter: () => void;
 }) {
   return (
     <div>
       <h2 className="text-lg font-semibold">{title}</h2>
       <p className="mb-3 text-sm text-slate-500">{subtitle}</p>
       {jobs.length === 0 ? (
-        <EmptyState
-          title="No jobs yet"
-          description="No jobs match this filter yet."
-        />
+        filterActive && allJobs.length > 0 ? (
+          <NoResultsState
+            title="No jobs match this filter"
+            description="Try a different status or clear the filter to show every job in this section."
+            actionLabel="Clear filter"
+            onAction={onClearFilter}
+          />
+        ) : (
+          <EmptyState
+            title="No jobs yet"
+            description="No jobs match this filter yet."
+          />
+        )
       ) : (
         <ul className="grid list-none gap-4 sm:grid-cols-2" aria-label={title}>
           {jobs.map(({ id, job }) => (
@@ -336,11 +364,7 @@ function JobCard({
     <article className="interactive-card h-full p-4">
       <div className="flex items-start justify-between gap-2">
         <h3 className="font-medium">Job #{id}</h3>
-        <span
-          className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
-        >
-          {STATUS_LABELS[job.status]}
-        </span>
+        <StatusPill status={job.status} />
       </div>
       <div className="mt-2 space-y-1 text-sm text-slate-600">
         <p className="flex min-w-0 items-baseline gap-1">

--- a/frontend/app/disputes/page.tsx
+++ b/frontend/app/disputes/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useModalFocusTrap } from "@/lib/modal";
 import { useWallet } from "@/lib/wallet-context";
 import EmptyState from "@/components/EmptyState";
+import NoResultsState from "@/components/NoResultsState";
 import SectionCard from "@/components/SectionCard";
 import {
   loadDisputesPageData,
@@ -683,17 +684,27 @@ export default function DisputesPage() {
             </button>
           </div>
         ) : filteredDisputes.length === 0 ? (
-          <EmptyState
-            title="No disputes found"
-            description={
-              filter === "active"
-                ? "No active disputes yet."
-                : filter === "resolved"
-                  ? "No resolved disputes yet."
-                  : "No disputes yet."
-            }
-            className="border-slate-200 bg-slate-50"
-          />
+          filter !== "all" && disputes.length > 0 ? (
+            <NoResultsState
+              title="No disputes match this filter"
+              description="Try a different tab or clear the filter to see every dispute."
+              actionLabel="Show all disputes"
+              onAction={() => setFilter("all")}
+              className="border-slate-200 bg-slate-50"
+            />
+          ) : (
+            <EmptyState
+              title="No disputes found"
+              description={
+                filter === "active"
+                  ? "No active disputes yet."
+                  : filter === "resolved"
+                    ? "No resolved disputes yet."
+                    : "No disputes yet."
+              }
+              className="border-slate-200 bg-slate-50"
+            />
+          )
         ) : (
           <div className="space-y-3">
             {filteredDisputes.map(d => (

--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import CancelJobConfirmModal from "@/components/CancelJobConfirmModal";
+import InfoTooltip from "@/components/InfoTooltip";
 import LoadingState from "@/components/LoadingState";
 import { useToast } from "@/components/ToastProvider";
+import StatusPill from "@/components/StatusPill";
 import { acceptJob, approveWork, cancelJob, getJob, submitWork } from "@/lib/contract";
 import { formatDeadline, toXlm } from "@/lib/format";
 import { getExplorerTxUrl } from "@/lib/stellar";
@@ -154,10 +156,23 @@ export default function JobDetailPage() {
     return (
       <section className="space-y-4">
         <h1 className="text-2xl font-semibold">Job #{id}</h1>
-        <p className="text-sm text-slate-700">{error ?? "Job not found."}</p>
-        <Link href="/" className="text-sm text-blue-600 hover:underline">
-          Back to Home
-        </Link>
+        <div className="rounded-lg border border-slate-200 bg-white p-5 text-sm">
+          <p className="text-slate-700">{error ?? "Job not found."}</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {error && error !== "Job not found." && (
+              <button
+                type="button"
+                onClick={() => void load()}
+                className="rounded-md bg-slate-900 px-4 py-2 font-medium text-white hover:bg-slate-700"
+              >
+                Retry
+              </button>
+            )}
+            <Link href="/" className="rounded-md border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-50">
+              Back to Home
+            </Link>
+          </div>
+        </div>
       </section>
     );
   }
@@ -192,7 +207,7 @@ export default function JobDetailPage() {
 
       <article className="space-y-2 rounded-lg border border-slate-200 bg-white p-5 text-sm">
         <p>
-          <strong>Status:</strong> {job.status}
+          <strong>Status:</strong> <StatusPill status={job.status} />
         </p>
         <p>
           <strong>Client:</strong> {job.client}
@@ -206,9 +221,16 @@ export default function JobDetailPage() {
         <p>
           <strong>Description:</strong> {getDescription(job.description_hash)}
         </p>
-        <div className="flex items-center gap-2">
-          <p>
-            <strong>Description hash:</strong>{" "}
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="flex items-center gap-2">
+            <strong className="inline-flex items-center gap-2">
+              Description hash
+              <InfoTooltip
+                label="Description hash help"
+                content="This hash identifies the stored job description and is useful when comparing records across devices."
+              />
+              :
+            </strong>
             <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">
               {job.description_hash}
             </code>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,8 @@
 
 import ErrorBanner from "@/components/ErrorBanner";
 import EmptyState from "@/components/EmptyState";
+import InfoTooltip from "@/components/InfoTooltip";
+import NoResultsState from "@/components/NoResultsState";
 import JobCardSkeleton from "@/components/JobCardSkeleton";
 import SectionCard from "@/components/SectionCard";
 import { acceptJob, getJob, getJobCount } from "@/lib/contract";
@@ -49,6 +51,10 @@ export default function HomePage() {
   }, []);
 
   useEffect(() => {
+    if (viewMode === "grid") {
+      sessionStorage.removeItem(VIEW_MODE_STORAGE_KEY);
+      return;
+    }
     sessionStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
   }, [viewMode]);
 
@@ -73,6 +79,10 @@ export default function HomePage() {
   }, []);
 
   useEffect(() => {
+    if (bookmarkedIds.length === 0) {
+      localStorage.removeItem(BOOKMARK_STORAGE_KEY);
+      return;
+    }
     localStorage.setItem(BOOKMARK_STORAGE_KEY, JSON.stringify(bookmarkedIds));
   }, [bookmarkedIds]);
 
@@ -231,13 +241,22 @@ export default function HomePage() {
         </button>
       </div>
 
-      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
+      {error && (
+        <ErrorBanner
+          message={error}
+          onDismiss={() => setError(null)}
+          onRetry={() => void refresh()}
+        />
+      )}
 
       {loading && jobs.length === 0 && (
-        <div className="grid gap-4 md:grid-cols-2" aria-label="Loading open jobs">
+        <div className="space-y-4">
+          <p className="text-sm text-slate-600">Loading jobs...</p>
+          <div className="grid gap-4 md:grid-cols-2" aria-label="Loading open jobs">
           {Array.from({ length: 6 }).map((_, index) => (
             <JobCardSkeleton key={index} />
           ))}
+          </div>
         </div>
       )}
 
@@ -271,14 +290,21 @@ export default function HomePage() {
       )}
 
       {!loading && visibleJobs.length === 0 && !error && (
-        <EmptyState
-          title={showBookmarkedOnly ? "No favorites found" : "No open jobs found"}
-          description={
-            showBookmarkedOnly
-              ? "Bookmark jobs to quickly find them here."
-              : "New jobs will appear here as clients post them."
-          }
-        />
+        <>
+          {showBookmarkedOnly && jobs.length > 0 ? (
+            <NoResultsState
+              title="No favorites found"
+              description="No bookmarked jobs match the current feed. Turn off favorites only to see everything again."
+              actionLabel="Show all jobs"
+              onAction={() => setShowBookmarkedOnly(false)}
+            />
+          ) : (
+            <EmptyState
+              title="No open jobs found"
+              description="New jobs will appear here as clients post them."
+            />
+          )}
+        </>
       )}
 
       <SectionCard
@@ -290,7 +316,13 @@ export default function HomePage() {
             Sort and filter job results
           </legend>
           <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
-            <label htmlFor="jobs-sort-order">Sort:</label>
+            <div className="inline-flex items-center gap-2">
+              <label htmlFor="jobs-sort-order">Sort:</label>
+              <InfoTooltip
+                label="Sort and filter jobs help"
+                content="Newest first surfaces recent jobs at the top. Favorites only filters to bookmarked jobs in this browser."
+              />
+            </div>
             <select
               id="jobs-sort-order"
               value={sortOrder}
@@ -395,7 +427,10 @@ export default function HomePage() {
                     <h2 className="flex items-center gap-2 text-lg font-medium hover:underline">
                       Job #{id}
                       {newJobIds.has(id) && (
-                        <span className="inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-800">
+                        <span
+                          aria-hidden="true"
+                          className="inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-800"
+                        >
                           New
                         </span>
                       )}

--- a/frontend/app/profile/[address]/profile-page-client.tsx
+++ b/frontend/app/profile/[address]/profile-page-client.tsx
@@ -1,30 +1,13 @@
 "use client";
 
 import ErrorBanner from "@/components/ErrorBanner";
+import StatusPill from "@/components/StatusPill";
 import { getJob, getJobCount } from "@/lib/contract";
 import { toXlm } from "@/lib/format";
-import type { Job, JobStatus } from "@/lib/types";
+import type { Job } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
-
-const STATUS_LABELS: Record<JobStatus, string> = {
-  Open: "Open",
-  InProgress: "In Progress",
-  SubmittedForReview: "Submitted for Review",
-  Completed: "Completed",
-  Cancelled: "Cancelled",
-  Disputed: "Disputed",
-};
-
-const STATUS_COLORS: Record<JobStatus, string> = {
-  Open: "bg-blue-100 text-blue-800",
-  InProgress: "bg-yellow-100 text-yellow-800",
-  SubmittedForReview: "bg-purple-100 text-purple-800",
-  Completed: "bg-green-100 text-green-800",
-  Cancelled: "bg-red-100 text-red-800",
-  Disputed: "bg-orange-100 text-orange-800",
-};
 
 function isValidStellarAddress(address: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(address);
@@ -154,7 +137,13 @@ export default function ProfilePageClient({ address }: { address: string }) {
         </div>
       </div>
 
-      {error && <ErrorBanner message={error} onDismiss={() => setError(null)} />}
+      {error && (
+        <ErrorBanner
+          message={error}
+          onDismiss={() => setError(null)}
+          onRetry={() => void fetchJobs()}
+        />
+      )}
       {loading && <p className="text-sm text-slate-600">Loading job history...</p>}
 
       {!loading && (
@@ -219,11 +208,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
                         </th>
                         <td className="py-2 pr-4 capitalize">{role}</td>
                         <td className="py-2 pr-4">
-                          <span
-                            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[job.status]}`}
-                          >
-                            {STATUS_LABELS[job.status]}
-                          </span>
+                          <StatusPill status={job.status} />
                         </td>
                         <td className="py-2 pr-4 text-right">
                           <span className="inline-flex min-w-0 items-baseline justify-end gap-1">

--- a/frontend/components/ErrorBanner.tsx
+++ b/frontend/components/ErrorBanner.tsx
@@ -3,25 +3,41 @@
 type ErrorBannerProps = {
   message: string;
   onDismiss?: () => void;
+  onRetry?: () => void;
 };
 
-export default function ErrorBanner({ message, onDismiss }: ErrorBannerProps) {
+export default function ErrorBanner({
+  message,
+  onDismiss,
+  onRetry,
+}: ErrorBannerProps) {
   return (
     <div
       role="alert"
-      className="flex items-center justify-between gap-3 rounded-md bg-red-100 p-3 text-sm text-red-700"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-md bg-red-100 p-3 text-sm text-red-700"
     >
-      <span>{message}</span>
-      {onDismiss && (
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="rounded px-2 py-1 font-semibold text-red-800 hover:bg-red-200"
-          aria-label="Dismiss error"
-        >
-          X
-        </button>
-      )}
+      <span className="min-w-0 flex-1">{message}</span>
+      <div className="flex items-center gap-2">
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded px-2 py-1 font-semibold text-red-800 hover:bg-red-200"
+          >
+            Retry
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded px-2 py-1 font-semibold text-red-800 hover:bg-red-200"
+            aria-label="Dismiss error"
+          >
+            X
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/components/InfoTooltip.tsx
+++ b/frontend/components/InfoTooltip.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useId } from "react";
+
+type InfoTooltipProps = {
+  label: string;
+  content: string;
+  className?: string;
+};
+
+export default function InfoTooltip({
+  label,
+  content,
+  className = "",
+}: InfoTooltipProps) {
+  const tooltipId = useId();
+
+  return (
+    <span className={`group relative inline-flex ${className}`.trim()}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-describedby={tooltipId}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 transition-colors hover:border-slate-400 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+      >
+        ?
+      </button>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-64 -translate-x-1/2 rounded-md bg-slate-900 px-3 py-2 text-xs leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {content}
+      </span>
+    </span>
+  );
+}

--- a/frontend/components/NoResultsState.tsx
+++ b/frontend/components/NoResultsState.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+type NoResultsStateProps = {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  className?: string;
+};
+
+export default function NoResultsState({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  className = "",
+}: NoResultsStateProps) {
+  return (
+    <div
+      className={`rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-10 text-center sm:px-6 sm:py-12 ${className}`.trim()}
+    >
+      <p className="font-medium text-slate-700">{title}</p>
+      <p className="mt-1 text-sm text-slate-500">{description}</p>
+      {actionLabel && onAction && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="mt-4 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/StatusPill.tsx
+++ b/frontend/components/StatusPill.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { JobStatus } from "@/lib/types";
+
+const STATUS_META: Record<JobStatus, { label: string; className: string }> = {
+  Open: {
+    label: "Open",
+    className: "bg-blue-100 text-blue-800 ring-blue-200",
+  },
+  InProgress: {
+    label: "In Progress",
+    className: "bg-yellow-100 text-yellow-800 ring-yellow-200",
+  },
+  SubmittedForReview: {
+    label: "Submitted for Review",
+    className: "bg-purple-100 text-purple-800 ring-purple-200",
+  },
+  Completed: {
+    label: "Completed",
+    className: "bg-green-100 text-green-800 ring-green-200",
+  },
+  Cancelled: {
+    label: "Cancelled",
+    className: "bg-red-100 text-red-800 ring-red-200",
+  },
+  Disputed: {
+    label: "Disputed",
+    className: "bg-orange-100 text-orange-800 ring-orange-200",
+  },
+};
+
+export function getJobStatusLabel(status: JobStatus) {
+  return STATUS_META[status].label;
+}
+
+export default function StatusPill({
+  status,
+  className = "",
+}: {
+  status: JobStatus;
+  className?: string;
+}) {
+  const meta = STATUS_META[status];
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${meta.className} ${className}`.trim()}
+    >
+      {meta.label}
+    </span>
+  );
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -76,7 +76,8 @@ export async function signTransaction(xdrValue: string): Promise<string> {
   return "signedTxXdr" in signed ? signed.signedTxXdr : signed;
 }
 
-const READONLY_SOURCE = Keypair.random().publicKey();
+// Use a stable placeholder account for read-only simulations when no wallet is connected.
+const READONLY_SOURCE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
 export async function callContract(
   contractId: string,

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,8 +1,46 @@
 import '@testing-library/jest-dom'
 import { crypto } from 'node:crypto'
 
+function createStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  } as Storage;
+}
+
 // Polyfill crypto for stellar-sdk in node/jsdom environment
 if (!globalThis.crypto) {
   // @ts-expect-error - jsdom needs a crypto polyfill for stellar-sdk
   globalThis.crypto = crypto
+}
+
+if (!globalThis.localStorage || typeof globalThis.localStorage.getItem !== 'function') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: createStorage(),
+    configurable: true,
+  })
+}
+
+if (!globalThis.sessionStorage || typeof globalThis.sessionStorage.getItem !== 'function') {
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: createStorage(),
+    configurable: true,
+  })
 }


### PR DESCRIPTION
Adds reusable UI primitives for job status, tooltips, and no-results states, plus retryable read errors across the main flows.

Closes #162
Closes #156
Closes #158
Closes #159