### PR TITLE
test: add contract, wallet, and home empty-state coverage (FE-TEST-19…

### DIFF
--- a/frontend/__tests__/contract.test.ts
+++ b/frontend/__tests__/contract.test.ts
@@ -1,40 +1,83 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+const mockCallContract = vi.fn();
 
 vi.mock("../lib/stellar", () => ({
-  callContract: vi.fn(),
+  callContract: (...args: unknown[]) => mockCallContract(...args),
   nativeToScVal: vi.fn((value: unknown) => value),
 }));
 
-import { hexToBytes, requireContractId } from "../lib/contract";
+import {
+  getJob,
+  hexToBytes,
+  postJob,
+  requireContractId,
+} from "../lib/contract";
 
-describe("lib/contract helpers", () => {
+const CONTRACT_ID_ERROR = "NEXT_PUBLIC_CONTRACT_ID is not configured.";
+
+describe("hexToBytes", () => {
+  it("parses valid hex strings to bytes", () => {
+    expect(Array.from(hexToBytes("0a10ff"))).toEqual([10, 16, 255]);
+    expect(Array.from(hexToBytes("0A10FF"))).toEqual([10, 16, 255]);
+  });
+
+  it("strips a 0x prefix before parsing", () => {
+    expect(Array.from(hexToBytes("0x0a10ff"))).toEqual([10, 16, 255]);
+    expect(Array.from(hexToBytes("0x0A10FF"))).toEqual([10, 16, 255]);
+  });
+
+  it("throws for odd-length hex strings", () => {
+    expect(() => hexToBytes("abc")).toThrow("Invalid hex input.");
+    expect(() => hexToBytes("0xabc")).toThrow("Invalid hex input.");
+  });
+
+  it("throws for non-hex characters", () => {
+    expect(() => hexToBytes("zz")).toThrow("Invalid hex input.");
+    expect(() => hexToBytes("0x12gh")).toThrow("Invalid hex input.");
+  });
+});
+
+describe("requireContractId", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("hexToBytes converts a valid hex string", () => {
-    expect(Array.from(hexToBytes("0x0a10ff"))).toEqual([10, 16, 255]);
-    expect(Array.from(hexToBytes("0A10FF"))).toEqual([10, 16, 255]);
-  });
-
-  it("hexToBytes throws for odd-length hex strings", () => {
-    expect(() => hexToBytes("abc")).toThrow("Invalid hex input.");
-  });
-
-  it("hexToBytes throws for non-hex characters", () => {
-    expect(() => hexToBytes("zz")).toThrow("Invalid hex input.");
-    expect(() => hexToBytes("0x12gh")).toThrow("Invalid hex input.");
-  });
-
-  it("requireContractId returns env contract id when set", () => {
+  it("returns the configured contract id", () => {
     vi.stubEnv("NEXT_PUBLIC_CONTRACT_ID", "CA12345");
     expect(requireContractId()).toBe("CA12345");
   });
 
-  it("requireContractId throws when env contract id is missing", () => {
+  it("throws when the contract id env var is empty", () => {
     vi.stubEnv("NEXT_PUBLIC_CONTRACT_ID", "");
-    expect(() => requireContractId()).toThrow(
-      "NEXT_PUBLIC_CONTRACT_ID is not configured.",
-    );
+    expect(() => requireContractId()).toThrow(CONTRACT_ID_ERROR);
+  });
+
+  it("throws when the contract id env var is unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_CONTRACT_ID", undefined);
+    expect(() => requireContractId()).toThrow(CONTRACT_ID_ERROR);
+  });
+});
+
+describe("contract calls without NEXT_PUBLIC_CONTRACT_ID", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_CONTRACT_ID", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("postJob fails fast before calling the contract", async () => {
+    await expect(
+      postJob("GCLIENT", "100", "0x0a", 4, "0", "GTOKEN"),
+    ).rejects.toThrow(CONTRACT_ID_ERROR);
+    expect(mockCallContract).not.toHaveBeenCalled();
+  });
+
+  it("getJob fails fast before calling the contract", async () => {
+    await expect(getJob("1")).rejects.toThrow(CONTRACT_ID_ERROR);
+    expect(mockCallContract).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/home-empty-state.test.tsx
+++ b/frontend/__tests__/home-empty-state.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import HomePage from "@/app/page";
+
+const mockGetJobCount = vi.fn();
+const mockGetJob = vi.fn();
+
+vi.mock("@/lib/contract", () => ({
+  getJobCount: (...args: unknown[]) => mockGetJobCount(...args),
+  getJob: (...args: unknown[]) => mockGetJob(...args),
+  acceptJob: vi.fn(),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => ({
+    wallet: null,
+    connectWallet: vi.fn(),
+  }),
+}));
+
+describe("Home page empty job state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows the empty state message when no jobs exist", async () => {
+    mockGetJobCount.mockResolvedValue(0);
+
+    render(<HomePage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No open jobs found")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("New jobs will appear here as clients post them."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the post job CTA in the hero section", async () => {
+    mockGetJobCount.mockResolvedValue(0);
+
+    render(<HomePage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No open jobs found")).toBeInTheDocument(),
+    );
+
+    const postJobLink = screen.getByRole("link", { name: "Post a Job" });
+    expect(postJobLink).toBeInTheDocument();
+    expect(postJobLink).toHaveAttribute("href", "/post-job");
+  });
+
+  it("does not render job cards when the feed is empty", async () => {
+    mockGetJobCount.mockResolvedValue(0);
+
+    render(<HomePage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No open jobs found")).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByRole("heading", { name: /^Job #/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Accept Job" })).not.toBeInTheDocument();
+    expect(mockGetJob).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/stellar.test.ts
+++ b/frontend/__tests__/stellar.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIsAllowed = vi.fn();
+const mockGetAddress = vi.fn();
+
+vi.mock("@stellar/freighter-api", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+  requestAccess: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+import { getPublicKey } from "../lib/stellar";
+
+describe("getPublicKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when Freighter access is not allowed", async () => {
+    mockIsAllowed.mockResolvedValue({ isAllowed: false });
+
+    await expect(getPublicKey()).resolves.toBeNull();
+    expect(mockGetAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns the wallet address when Freighter access is allowed", async () => {
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GALLOWEDWALLET" });
+
+    await expect(getPublicKey()).resolves.toBe("GALLOWEDWALLET");
+  });
+
+  it("returns null when Freighter getAddress reports an error", async () => {
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ error: "User rejected request" });
+
+    await expect(getPublicKey()).resolves.toBeNull();
+  });
+});

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -311,14 +311,13 @@ export default function HomePage() {
       {loading && jobs.length === 0 && (
         <div className="space-y-4">
           <p className="text-sm text-slate-600">Loading jobs...</p>
-          <div className="grid gap-4 md:grid-cols-2" aria-label="Loading open jobs">
-        <div
-          className={viewMode === "list" ? "flex flex-col gap-4" : "grid gap-4 md:grid-cols-2"}
-          aria-label="Loading open jobs"
-        >
-          {Array.from({ length: 6 }).map((_, index) => (
-            <JobCardSkeleton key={index} compact={viewMode === "list"} />
-          ))}
+          <div
+            className={viewMode === "list" ? "flex flex-col gap-4" : "grid gap-4 md:grid-cols-2"}
+            aria-label="Loading open jobs"
+          >
+            {Array.from({ length: 6 }).map((_, index) => (
+              <JobCardSkeleton key={index} compact={viewMode === "list"} />
+            ))}
           </div>
         </div>
       )}
@@ -353,37 +352,31 @@ export default function HomePage() {
       )}
 
       {!loading && visibleJobs.length === 0 && !error && (
-        <>
-          {showBookmarkedOnly && jobs.length > 0 ? (
-            <NoResultsState
-              title="No favorites found"
-              description="No bookmarked jobs match the current feed. Turn off favorites only to see everything again."
-              actionLabel="Show all jobs"
-              onAction={() => setShowBookmarkedOnly(false)}
-            />
-          ) : (
-            <EmptyState
-              title="No open jobs found"
-              description="New jobs will appear here as clients post them."
-            />
-          )}
-        </>
-        <EmptyState
-          title={
-            normalizedSearchTerm
-              ? "No jobs match your search"
-              : showBookmarkedOnly
-                ? "No favorites found"
-                : "No open jobs found"
-          }
-          description={
-            normalizedSearchTerm
-              ? "Try a different keyword or clear your search history."
-              : showBookmarkedOnly
-                ? "Bookmark jobs to quickly find them here."
-                : "New jobs will appear here as clients post them."
-          }
-        />
+        showBookmarkedOnly && jobs.length > 0 && !normalizedSearchTerm ? (
+          <NoResultsState
+            title="No favorites found"
+            description="No bookmarked jobs match the current feed. Turn off favorites only to see everything again."
+            actionLabel="Show all jobs"
+            onAction={() => setShowBookmarkedOnly(false)}
+          />
+        ) : (
+          <EmptyState
+            title={
+              normalizedSearchTerm
+                ? "No jobs match your search"
+                : showBookmarkedOnly
+                  ? "No favorites found"
+                  : "No open jobs found"
+            }
+            description={
+              normalizedSearchTerm
+                ? "Try a different keyword or clear your search history."
+                : showBookmarkedOnly
+                  ? "Bookmark jobs to quickly find them here."
+                  : "New jobs will appear here as clients post them."
+            }
+          />
+        )
       )}
 
       <SectionCard


### PR DESCRIPTION
## Summary

Adds frontend unit and component test coverage for issues #289–#292 (FE-TEST-19 through FE-TEST-22):

- **#290 (FE-TEST-20):** Unit tests for `hexToBytes` — valid hex parsing, odd-length rejection, and `0x` prefix handling
- **#291 (FE-TEST-21):** Unit tests for `requireContractId` guard — verifies `postJob` and `getJob` fail fast with a clear error when `NEXT_PUBLIC_CONTRACT_ID` is unset
- **#289 (FE-TEST-19):** Unit tests for `getPublicKey` — null when Freighter not allowed, address when allowed, graceful handling of Freighter errors
- **#292 (FE-TEST-22):** Component tests for home page empty job feed — empty state copy, Post a Job CTA, and no broken job cards

Also fixes invalid JSX in `frontend/app/page.tsx` (loading skeleton nesting and duplicate empty-state blocks) that prevented home page component tests from compiling.

## Changes

| File | Change |
|------|--------|
| `frontend/__tests__/contract.test.ts` | Expanded `hexToBytes` / `requireContractId` tests; added `postJob` / `getJob` guard tests |
| `frontend/__tests__/stellar.test.ts` | **New** — `getPublicKey` Freighter permission tests |
| `frontend/__tests__/home-empty-state.test.tsx` | **New** — home page empty feed component tests |
| `frontend/app/page.tsx` | Fix JSX syntax in loading skeleton and empty-state rendering |

## Test plan

- [x] `npx vitest run __tests__/contract.test.ts`
- [x] `npx vitest run __tests__/stellar.test.ts`
- [x] `npx vitest run __tests__/home-empty-state.test.tsx`
- [x] `npx vitest run __tests__/smoke.test.tsx`
- [ ] Full suite: `cd frontend && npm test`

Closes #289
Closes #290
Closes #291 
Closes #292