### PR TITLE
test(frontend): add tests for post-job, profile, header nav, and callContract

### DIFF
--- a/frontend/__tests__/callcontract-simulation.test.ts
+++ b/frontend/__tests__/callcontract-simulation.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Spy state shared with the stellar-sdk mock.
+const simulateTransaction = vi.fn();
+const sendTransaction = vi.fn();
+const prepareTransaction = vi.fn();
+const getAccount = vi.fn();
+const assembleTransactionBuild = vi.fn();
+const isSimulationError = vi.fn();
+const isSimulationSuccess = vi.fn();
+const signTransactionSpy = vi.fn();
+
+const isAllowedMock = vi.fn();
+const getAddressMock = vi.fn();
+const requestAccessMock = vi.fn();
+
+class FakeAccount {
+  constructor(public id: string, public sequence: string) {}
+  accountId() {
+    return this.id;
+  }
+  incrementSequenceNumber() {}
+  sequenceNumber() {
+    return this.sequence;
+  }
+}
+
+class FakeContract {
+  constructor(public contractId: string) {}
+  call(method: string, ...args: unknown[]) {
+    return { __op: "call", method, args };
+  }
+}
+
+class FakeTransactionBuilder {
+  private operations: unknown[] = [];
+  constructor(public source: unknown, public opts: unknown) {}
+  addOperation(op: unknown) {
+    this.operations.push(op);
+    return this;
+  }
+  setTimeout() {
+    return this;
+  }
+  build() {
+    return { __tx: true, source: this.source, operations: this.operations };
+  }
+  static fromXDR(xdrValue: string) {
+    return { __tx: true, fromXdr: xdrValue };
+  }
+}
+
+const sdkMocks = {
+  Account: FakeAccount,
+  BASE_FEE: "100",
+  Contract: FakeContract,
+  Keypair: { random: () => ({ publicKey: () => "GANY" }) },
+  Networks: { PUBLIC: "Public", TESTNET: "Test SDF Network ; September 2015" },
+  nativeToScVal: (value: unknown) => ({ __scval: value }),
+  rpc: {
+    Server: vi.fn().mockImplementation(() => ({
+      getAccount,
+      simulateTransaction,
+      sendTransaction,
+      prepareTransaction,
+      getTransaction: vi.fn(),
+    })),
+    Api: {
+      isSimulationError: (sim: unknown) => isSimulationError(sim),
+      isSimulationSuccess: (sim: unknown) => isSimulationSuccess(sim),
+      SendTransactionStatus: { ERROR: "ERROR", PENDING: "PENDING", SUCCESS: "SUCCESS" },
+      GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED" },
+    },
+    assembleTransaction: vi.fn(() => ({ build: assembleTransactionBuild })),
+  },
+  scValToNative: (value: unknown) => {
+    if (value && typeof value === "object" && "__decoded" in value) {
+      return (value as { __decoded: unknown }).__decoded;
+    }
+    return value;
+  },
+  TransactionBuilder: FakeTransactionBuilder,
+  xdr: {},
+};
+
+vi.mock("@stellar/stellar-sdk", () => sdkMocks);
+
+vi.mock("@stellar/freighter-api", () => ({
+  getAddress: (...args: unknown[]) => getAddressMock(...args),
+  isAllowed: (...args: unknown[]) => isAllowedMock(...args),
+  requestAccess: vi.fn(),
+  signTransaction: (...args: unknown[]) => signTransactionSpy(...args),
+}));
+
+// Import the module under test AFTER mocks are registered.
+import { callContract } from "../lib/stellar";
+
+describe("callContract read-only simulation path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSimulationError.mockReturnValue(false);
+    isSimulationSuccess.mockReturnValue(true);
+    assembleTransactionBuild.mockReturnValue({ toXDR: () => "ASSEMBLED_XDR" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("simulates without signing and decodes the simulation retval", async () => {
+    // No wallet connected -> falls back to placeholder source.
+    isAllowedMock.mockResolvedValue({ isAllowed: false });
+    getAddressMock.mockResolvedValue({ address: null, error: "not allowed" });
+
+    simulateTransaction.mockResolvedValue({
+      result: { retval: { __decoded: 42 } },
+    });
+
+    const result = await callContract("CCONTRACT", "get_job_count", [], {
+      readOnly: true,
+    });
+
+    expect(result).toEqual({ status: "SUCCESS", data: 42 });
+    expect(simulateTransaction).toHaveBeenCalledTimes(1);
+
+    // No signing or sending should happen on a read-only path.
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+    expect(sendTransaction).not.toHaveBeenCalled();
+    expect(prepareTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns an error result when the simulation has no retval", async () => {
+    isAllowedMock.mockResolvedValue({ isAllowed: false });
+    getAddressMock.mockResolvedValue({ address: null, error: "not allowed" });
+
+    simulateTransaction.mockResolvedValue({ result: {} });
+
+    const result = await callContract("CCONTRACT", "get_job", [], {
+      readOnly: true,
+    });
+
+    expect(result.status).toBe("ERROR");
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates simulation errors as thrown exceptions", async () => {
+    isAllowedMock.mockResolvedValue({ isAllowed: false });
+    getAddressMock.mockResolvedValue({ address: null, error: "not allowed" });
+
+    isSimulationError.mockReturnValue(true);
+    simulateTransaction.mockResolvedValue({ error: "boom" });
+
+    await expect(
+      callContract("CCONTRACT", "get_job", [], { readOnly: true }),
+    ).rejects.toThrow("boom");
+
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when wallet is not connected and the call is not read-only", async () => {
+    isAllowedMock.mockResolvedValue({ isAllowed: false });
+    getAddressMock.mockResolvedValue({ address: null, error: "not allowed" });
+
+    await expect(
+      callContract("CCONTRACT", "post_job", []),
+    ).rejects.toThrow("Connect Freighter before calling contract.");
+
+    // It must not even attempt to simulate or sign.
+    expect(simulateTransaction).not.toHaveBeenCalled();
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses the wallet's account as the simulation source when one is connected", async () => {
+    isAllowedMock.mockResolvedValue({ isAllowed: true });
+    getAddressMock.mockResolvedValue({ address: "GWALLET", error: undefined });
+    getAccount.mockResolvedValue(new FakeAccount("GWALLET", "0"));
+
+    simulateTransaction.mockResolvedValue({
+      result: { retval: { __decoded: "value" } },
+    });
+
+    const result = await callContract("CCONTRACT", "get_job", [], {
+      readOnly: true,
+    });
+
+    expect(getAccount).toHaveBeenCalledWith("GWALLET");
+    expect(result).toEqual({ status: "SUCCESS", data: "value" });
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/layout-header-navigation.test.tsx
+++ b/frontend/__tests__/layout-header-navigation.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Navigation } from "@/app/navigation";
+
+const mockUseWallet = vi.fn();
+const mockUsePathname = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...rest }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+  WalletButton: () => <button type="button">Connect Wallet</button>,
+}));
+
+vi.mock("@/components/NetworkBadge", () => ({
+  default: () => <span data-testid="network-badge">testnet</span>,
+}));
+
+describe("Layout header navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWallet.mockReturnValue({ wallet: null, connectWallet: vi.fn() });
+    mockUsePathname.mockReturnValue("/");
+  });
+
+  it("renders the StellarWork brand link plus core navigation entries", () => {
+    render(<Navigation />);
+
+    // Brand link
+    const brand = screen.getByRole("link", { name: "StellarWork" });
+    expect(brand).toHaveAttribute("href", "/");
+
+    // The "Jobs" link points at home and Dashboard is exposed.
+    const nav = screen.getAllByRole("navigation", { name: "Main navigation" })[0];
+    expect(within(nav).getByRole("link", { name: "Jobs" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(within(nav).getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    expect(within(nav).getByRole("link", { name: "Post Job" })).toHaveAttribute(
+      "href",
+      "/post-job",
+    );
+    expect(within(nav).getByRole("link", { name: "Disputes" })).toHaveAttribute(
+      "href",
+      "/disputes",
+    );
+  });
+
+  it("highlights the active route with semibold styling", () => {
+    mockUsePathname.mockReturnValue("/dashboard");
+
+    render(<Navigation />);
+
+    const nav = screen.getAllByRole("navigation", { name: "Main navigation" })[0];
+    const dashboardLink = within(nav).getByRole("link", { name: "Dashboard" });
+    const jobsLink = within(nav).getByRole("link", { name: "Jobs" });
+
+    expect(dashboardLink).toHaveClass("font-semibold", "text-slate-900");
+    expect(jobsLink).not.toHaveClass("font-semibold");
+  });
+
+  it("marks the home link active only on the exact root path", () => {
+    mockUsePathname.mockReturnValue("/disputes");
+
+    render(<Navigation />);
+
+    const nav = screen.getAllByRole("navigation", { name: "Main navigation" })[0];
+    expect(within(nav).getByRole("link", { name: "Jobs" })).not.toHaveClass(
+      "font-semibold",
+    );
+    expect(within(nav).getByRole("link", { name: "Disputes" })).toHaveClass(
+      "font-semibold",
+    );
+  });
+
+  it("toggles the mobile menu open and closed via the menu button", () => {
+    render(<Navigation />);
+
+    const toggle = screen.getByRole("button", { name: /Toggle navigation menu/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // After opening, two navigation regions are present (desktop + mobile).
+    const navs = screen.getAllByRole("navigation", { name: "Main navigation" });
+    expect(navs.length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("exposes the Profile link only when a wallet is connected", () => {
+    const { rerender } = render(<Navigation />);
+
+    expect(screen.queryByRole("link", { name: "Profile" })).not.toBeInTheDocument();
+
+    mockUseWallet.mockReturnValue({
+      wallet: "GWALLET000000000000000000000000000000000000000000000000000",
+      connectWallet: vi.fn(),
+    });
+    rerender(<Navigation />);
+
+    const nav = screen.getAllByRole("navigation", { name: "Main navigation" })[0];
+    const profileLink = within(nav).getByRole("link", { name: "Profile" });
+    expect(profileLink).toHaveAttribute(
+      "href",
+      "/profile/GWALLET000000000000000000000000000000000000000000000000000",
+    );
+  });
+});

--- a/frontend/__tests__/post-job-amount-validation.test.tsx
+++ b/frontend/__tests__/post-job-amount-validation.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PostJobPage from "@/app/post-job/page";
+
+const mockPostJob = vi.fn();
+const mockGetDescPayloadMax = vi.fn();
+const mockUseWallet = vi.fn();
+
+vi.mock("@/lib/contract", () => ({
+  postJob: (...args: unknown[]) => mockPostJob(...args),
+  getDescPayloadMax: (...args: unknown[]) => mockGetDescPayloadMax(...args),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  getExplorerTxUrl: (hash: string) => `https://example.test/tx/${hash}`,
+}));
+
+const TOKEN_ADDRESS = "GTOKEN000000000000000000000000000000000000000000000000000";
+
+function fillRequiredFields({
+  amount,
+  description = "Build a landing page",
+}: {
+  amount: string;
+  description?: string;
+}) {
+  fireEvent.change(screen.getByLabelText(/Amount \(XLM\)/), {
+    target: { value: amount },
+  });
+  fireEvent.change(screen.getByLabelText(/Job Description/), {
+    target: { value: description },
+  });
+  fireEvent.change(screen.getByLabelText(/Token Address/), {
+    target: { value: TOKEN_ADDRESS },
+  });
+}
+
+describe("Post job amount input validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockGetDescPayloadMax.mockResolvedValue(4096);
+    mockPostJob.mockResolvedValue({ hash: "TX_OK", status: "SUCCESS" });
+    mockUseWallet.mockReturnValue({
+      wallet: "GWALLET000000000000000000000000000000000000000000000000000",
+      connectWallet: vi.fn(),
+    });
+  });
+
+  it("blocks non-numeric amount input by enforcing a numeric field", () => {
+    render(<PostJobPage />);
+
+    const amountInput = screen.getByLabelText(/Amount \(XLM\)/) as HTMLInputElement;
+
+    // The amount field is a number input so the browser/jsdom rejects
+    // non-numeric strings; the underlying value remains empty.
+    fireEvent.change(amountInput, { target: { value: "abc" } });
+
+    expect(amountInput).toHaveAttribute("type", "number");
+    expect(amountInput.value).toBe("");
+  });
+
+  it("shows an error and does not submit when amount is zero", async () => {
+    render(<PostJobPage />);
+
+    fillRequiredFields({ amount: "0" });
+    fireEvent.submit(screen.getByRole("button", { name: /Post Job/ }).closest("form")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Enter a valid amount with up to 7 decimal places\./)
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByLabelText(/Amount \(XLM\)/)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(mockPostJob).not.toHaveBeenCalled();
+  });
+
+  it("submits successfully when a positive amount is provided", async () => {
+    render(<PostJobPage />);
+
+    fillRequiredFields({ amount: "1.5" });
+    fireEvent.submit(screen.getByRole("button", { name: /Post Job/ }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockPostJob).toHaveBeenCalledTimes(1);
+    });
+
+    // Amount is converted to stroops (1.5 XLM -> "15000000")
+    expect(mockPostJob.mock.calls[0][1]).toBe("15000000");
+
+    // Amount field has no validation error after a successful submit
+    expect(
+      screen.queryAllByText(/Enter a valid amount with up to 7 decimal places\./),
+    ).toHaveLength(0);
+  });
+
+  it("rejects amounts with more than seven decimal places", async () => {
+    render(<PostJobPage />);
+
+    fillRequiredFields({ amount: "0.12345678" });
+    fireEvent.submit(screen.getByRole("button", { name: /Post Job/ }).closest("form")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Enter a valid amount with up to 7 decimal places\./)
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(mockPostJob).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/profile-address-display.test.tsx
+++ b/frontend/__tests__/profile-address-display.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ProfilePageClient from "@/app/profile/[address]/profile-page-client";
+import { generateMetadata } from "@/app/profile/[address]/page";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockWalletContext = {
+  wallet: null as string | null,
+  connectWallet: vi.fn(),
+};
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockWalletContext,
+}));
+
+vi.mock("@/lib/contract", () => ({
+  getJob: vi.fn(),
+  getJobCount: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("@/lib/format", () => ({
+  toXlm: (value: bigint | string) => `${Number(value) / 10000000}`,
+}));
+
+const VALID_ADDRESS = "GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV";
+const ANOTHER_VALID_ADDRESS =
+  "GTEST123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJ";
+
+describe("Profile page address display", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWalletContext.wallet = null;
+  });
+
+  it("renders the full Stellar address verbatim once the wallet is connected", async () => {
+    mockWalletContext.wallet = ANOTHER_VALID_ADDRESS;
+
+    render(<ProfilePageClient address={VALID_ADDRESS} />);
+
+    // The address should be shown in full (no truncation), in a monospace block.
+    const addressNode = await screen.findByText(VALID_ADDRESS);
+    expect(addressNode).toBeInTheDocument();
+    expect(addressNode).toHaveClass("font-mono");
+    expect(addressNode.textContent?.length).toBe(56);
+  });
+
+  it("handles invalid address routes with a fallback message that echoes the input", () => {
+    const invalidAddress = "NOT-A-VALID-ADDRESS";
+
+    render(<ProfilePageClient address={invalidAddress} />);
+
+    expect(screen.getByText("Invalid Address")).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`${invalidAddress}.*not a valid Stellar address`)),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Stellar addresses start with .*G.*56 characters long/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the on-chain address block on the invalid route", () => {
+    render(<ProfilePageClient address="bogus" />);
+
+    // The mono-font address paragraph used on the valid view must not appear.
+    expect(screen.queryByText(/^G[A-Z2-7]{55}$/)).not.toBeInTheDocument();
+  });
+
+  it("includes the address in the page metadata title for valid addresses", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ address: VALID_ADDRESS }),
+    });
+
+    expect(metadata.title).toBe(`Profile | ${VALID_ADDRESS} | StellarWork`);
+    expect(metadata.description).toContain(VALID_ADDRESS);
+  });
+
+  it("uses an explicit invalid-address metadata title when the route is malformed", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ address: "not-valid" }),
+    });
+
+    expect(metadata.title).toBe("Profile | Invalid Address | StellarWork");
+    expect(metadata.description?.toLowerCase()).toContain("invalid");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused frontend tests across four areas. Each test file is independent and uses the existing Vitest + React Testing Library setup; no new tooling is introduced.

- `frontend/__tests__/post-job-amount-validation.test.tsx` — verifies non-numeric input is rejected by the number input, zero amount surfaces the validation error and blocks contract submission, valid amounts are converted to stroops and submitted, and amounts with more than seven decimal places are rejected.
- `frontend/__tests__/profile-address-display.test.tsx` — verifies the full Stellar address renders verbatim in the monospace block, invalid routes show the fallback that echoes the input, and `generateMetadata` includes the address in the page title (with an explicit invalid-address title for malformed routes).
- `frontend/__tests__/layout-header-navigation.test.tsx` — verifies the brand and core links (Jobs/Post Job/Dashboard/Disputes) render with correct hrefs, the active route is highlighted, the home link only matches the exact root, the mobile menu toggles via the menu button, and the Profile link appears only with a connected wallet.
- `frontend/__tests__/callcontract-simulation.test.ts` — mocks `@stellar/stellar-sdk` and `@stellar/freighter-api` to verify the read-only path simulates and decodes the retval without ever signing or sending, simulation errors propagate as thrown errors, missing retval returns an error result, the non-read-only path throws when no wallet is connected, and a connected wallet's account is used as the simulation source.

closes #294
closes #295
closes #296
closes #297

## Notes

- Could not run `npm install` / `npm test` locally in this environment; CI is the source of truth. Patterns mirror existing tests in `frontend/__tests__/` (e.g. `profile-fallback.test.tsx`, `home-layout-toggles.test.tsx`, `cancel-job-confirm.test.tsx`, `contract.test.ts`).
- No production code changes; tests only.

## Test plan

- [ ] `npm --prefix frontend test` passes for all four new files.
- [ ] No new lint warnings in the added files.