### PR TITLE
fix: reset pagination to page 1 when favorites filter changes

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -481,6 +481,7 @@ export default function HomePage() {
                 checked={showBookmarkedOnly}
                 onChange={(event) => {
                   setShowBookmarkedOnly(event.target.checked);
+                  setPage(1);
                 }}
                 className="h-4 w-4 rounded border-slate-300"
               />


### PR DESCRIPTION
closes #240 

This PR resolves the pagination bug where the page index was not resetting when the 'Favorites only' filter was toggled, causing blank page states when filtered results were fewer than the current page offset.

## Changes

- Added `setPage(1)` call in the `showBookmarkedOnly` filter's `onChange` handler
- This matches the existing pattern used for other filter changes (search, sort order, page size)

## Acceptance Criteria Met

- ✅ Page resets to first on filter update
- ✅ No blank page state when toggling favorites filter
- ✅ URL params remain valid (no URL params are used in this implementation)

## Testing

**Before fix:**
1. Navigate to page 3 with many jobs visible
2. Toggle 'Favorites only' filter (assuming fewer than 30 bookmarked jobs)
3. Result: Blank page displayed

**After fix:**
1. Navigate to page 3 with many jobs visible
2. Toggle 'Favorites only' filter
3. Result: Automatically returns to page 1 with filtered results displayed

## Technical Details

The fix ensures consistency with other filter behaviors in the application:
- Search term changes → resets to page 1
- Sort order changes → resets to page 1
- Page size changes → resets to page 1
- **Favorites filter changes → now resets to page 1** 