### PR TITLE
test(frontend): sendTransaction errors, signTransaction propagation, post-job fields, disputes render

### DIFF
--- a/frontend/__tests__/callcontract-send-error.test.ts
+++ b/frontend/__tests__/callcontract-send-error.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Shared spy state (mirrors callcontract-simulation.test.ts pattern) ────────
+const simulateTransaction = vi.fn();
+const sendTransaction = vi.fn();
+const prepareTransaction = vi.fn();
+const getAccount = vi.fn();
+const getTransaction = vi.fn();
+const assembleTransactionBuild = vi.fn();
+const isSimulationError = vi.fn();
+const isSimulationSuccess = vi.fn();
+const signTransactionSpy = vi.fn();
+
+const isAllowedMock = vi.fn();
+const getAddressMock = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class _Account {
+    constructor(public id: string, public sequence: string) {}
+    accountId() { return this.id; }
+    incrementSequenceNumber() {}
+    sequenceNumber() { return this.sequence; }
+  }
+  class _Contract {
+    constructor(public contractId: string) {}
+    call(method: string, ...args: unknown[]) { return { __op: "call", method, args }; }
+  }
+  class _TransactionBuilder {
+    private operations: unknown[] = [];
+    constructor(public source: unknown, public opts: unknown) {}
+    addOperation(op: unknown) { this.operations.push(op); return this; }
+    setTimeout() { return this; }
+    build() { return { __tx: true, source: this.source, operations: this.operations }; }
+    static fromXDR(xdrValue: string) { return { __tx: true, fromXdr: xdrValue }; }
+  }
+  return {
+    Account: _Account,
+    BASE_FEE: "100",
+    Contract: _Contract,
+    Keypair: { random: () => ({ publicKey: () => "GANY" }) },
+    Networks: { PUBLIC: "Public", TESTNET: "Test SDF Network ; September 2015" },
+    nativeToScVal: (value: unknown) => ({ __scval: value }),
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount,
+        simulateTransaction,
+        sendTransaction,
+        prepareTransaction,
+        getTransaction,
+      })),
+      Api: {
+        isSimulationError: (sim: unknown) => isSimulationError(sim),
+        isSimulationSuccess: (sim: unknown) => isSimulationSuccess(sim),
+        SendTransactionStatus: { ERROR: "ERROR", PENDING: "PENDING", SUCCESS: "SUCCESS" },
+        GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED" },
+      },
+      assembleTransaction: vi.fn(() => ({ build: assembleTransactionBuild })),
+    },
+    scValToNative: (value: unknown) => value,
+    TransactionBuilder: _TransactionBuilder,
+    xdr: {},
+  };
+});
+
+vi.mock("@stellar/freighter-api", () => ({
+  getAddress: (...args: unknown[]) => getAddressMock(...args),
+  isAllowed: (...args: unknown[]) => isAllowedMock(...args),
+  requestAccess: vi.fn(),
+  signTransaction: (...args: unknown[]) => signTransactionSpy(...args),
+}));
+
+import { callContract } from "../lib/stellar";
+
+describe("callContract sendTransaction error path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Wallet connected
+    isAllowedMock.mockResolvedValue({ isAllowed: true });
+    getAddressMock.mockResolvedValue({ address: "GWALLET", error: undefined });
+    getAccount.mockResolvedValue({
+      id: "GWALLET",
+      accountId: () => "GWALLET",
+      incrementSequenceNumber: () => {},
+      sequenceNumber: () => "0",
+    });
+    // Simulation succeeds so we reach the send step
+    isSimulationError.mockReturnValue(false);
+    isSimulationSuccess.mockReturnValue(true);
+    simulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    assembleTransactionBuild.mockReturnValue({ toXDR: () => "ASSEMBLED_XDR" });
+    prepareTransaction.mockResolvedValue({ toXDR: () => "PREPARED_XDR" });
+    signTransactionSpy.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws when sendTransaction returns ERROR status", async () => {
+    sendTransaction.mockResolvedValue({
+      status: "ERROR",
+      errorResult: { toXDR: () => ({ toString: () => "ledger error" }) },
+    });
+
+    await expect(
+      callContract("CCONTRACT", "post_job", []),
+    ).rejects.toThrow();
+
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets to a non-pending state after sendTransaction ERROR", async () => {
+    sendTransaction.mockResolvedValue({
+      status: "ERROR",
+      errorResult: { toXDR: () => ({ toString: () => "err" }) },
+    });
+
+    let threw = false;
+    try {
+      await callContract("CCONTRACT", "post_job", []);
+    } catch {
+      threw = true;
+    }
+
+    // The call must have thrown (not hung in a pending loop)
+    expect(threw).toBe(true);
+    // sendTransaction called once — no polling loop entered
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns ERROR result when the polled transaction status is FAILED", async () => {
+    sendTransaction.mockResolvedValue({
+      status: "PENDING",
+      hash: "TX_HASH_FAIL",
+    });
+
+    getTransaction.mockResolvedValue({ status: "FAILED" });
+
+    const result = await callContract("CCONTRACT", "post_job", [], {
+      pollTimeout: 500,
+    });
+
+    expect(result.status).toBe("ERROR");
+    expect(result.hash).toBe("TX_HASH_FAIL");
+  });
+
+  it("does not call signTransaction when simulation itself errors", async () => {
+    isSimulationError.mockReturnValue(true);
+    simulateTransaction.mockResolvedValue({ error: "sim failed" });
+
+    await expect(
+      callContract("CCONTRACT", "post_job", []),
+    ).rejects.toThrow("sim failed");
+
+    expect(signTransactionSpy).not.toHaveBeenCalled();
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/disputes-page-render.test.tsx
+++ b/frontend/__tests__/disputes-page-render.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DisputesPage from "@/app/disputes/page";
+
+const mockLoadDisputesPageData = vi.fn();
+
+vi.mock("@/lib/disputes-loader", () => ({
+  loadDisputesPageData: (...args: unknown[]) =>
+    mockLoadDisputesPageData(...args),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => ({
+    wallet: "GTESTWALLET",
+    connectWallet: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/modal", () => ({
+  useModalFocusTrap: () => ({ current: null }),
+}));
+
+const makeDispute = (overrides = {}) => ({
+  id: "D-001",
+  jobId: "J-001",
+  jobTitle: "Build a portfolio site",
+  client: "Alice",
+  freelancer: "Bob",
+  amount: 500,
+  raisedBy: "client" as const,
+  raisedAt: "2026-01-10T10:00:00Z",
+  status: "Active" as const,
+  reason: "Work not delivered",
+  ...overrides,
+});
+
+describe("Disputes page render (#305)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the main Disputes heading", async () => {
+    mockLoadDisputesPageData.mockResolvedValue({
+      disputes: [],
+      eligibleJobs: [],
+    });
+
+    render(<DisputesPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("heading", { name: /disputes/i })[0],
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the empty state when there are no disputes", async () => {
+    mockLoadDisputesPageData.mockResolvedValue({
+      disputes: [],
+      eligibleJobs: [],
+    });
+
+    render(<DisputesPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/No disputes/i).length).toBeGreaterThan(0),
+    );
+  });
+
+  it("renders a populated dispute list with job title visible", async () => {
+    mockLoadDisputesPageData.mockResolvedValue({
+      disputes: [makeDispute()],
+      eligibleJobs: [],
+    });
+
+    render(<DisputesPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Build a portfolio site"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders multiple disputes in a list", async () => {
+    mockLoadDisputesPageData.mockResolvedValue({
+      disputes: [
+        makeDispute({ id: "D-001", jobTitle: "Logo design" }),
+        makeDispute({ id: "D-002", jobTitle: "API integration" }),
+      ],
+      eligibleJobs: [],
+    });
+
+    render(<DisputesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Logo design")).toBeInTheDocument();
+      expect(screen.getByText("API integration")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/post-job-form-fields.test.tsx
+++ b/frontend/__tests__/post-job-form-fields.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PostJobPage from "@/app/post-job/page";
+
+const mockPostJob = vi.fn();
+const mockGetDescPayloadMax = vi.fn();
+
+vi.mock("@/lib/contract", () => ({
+  postJob: (...args: unknown[]) => mockPostJob(...args),
+  getDescPayloadMax: (...args: unknown[]) => mockGetDescPayloadMax(...args),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => ({
+    wallet: "GWALLET000000000000000000000000000000000000000000000000000",
+    connectWallet: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/stellar", () => ({
+  getExplorerTxUrl: (hash: string) => `https://example.test/tx/${hash}`,
+}));
+
+describe("Post-job page: form fields presence (#306)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDescPayloadMax.mockResolvedValue(4096);
+  });
+
+  it("renders the page heading", () => {
+    render(<PostJobPage />);
+    expect(screen.getByRole("heading", { name: /post job/i })).toBeInTheDocument();
+  });
+
+  it("renders the Amount (XLM) input field", () => {
+    render(<PostJobPage />);
+    expect(screen.getByLabelText(/Amount \(XLM\)/i)).toBeInTheDocument();
+  });
+
+  it("renders the Job Description textarea", () => {
+    render(<PostJobPage />);
+    expect(screen.getByLabelText(/Job Description/i)).toBeInTheDocument();
+  });
+
+  it("renders the Token Address input field", () => {
+    render(<PostJobPage />);
+    expect(screen.getByLabelText(/Token Address/i)).toBeInTheDocument();
+  });
+
+  it("renders the submit button and it is initially enabled", () => {
+    render(<PostJobPage />);
+    const btn = screen.getByRole("button", { name: /post job/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("renders the Deadline (optional) date field", () => {
+    render(<PostJobPage />);
+    expect(screen.getByLabelText(/Deadline/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/sign-transaction-error.test.ts
+++ b/frontend/__tests__/sign-transaction-error.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Freighter mock ────────────────────────────────────────────────────────────
+const freighterSignTransaction = vi.fn();
+const isAllowedMock = vi.fn();
+const getAddressMock = vi.fn();
+
+vi.mock("@stellar/freighter-api", () => ({
+  isAllowed: (...args: unknown[]) => isAllowedMock(...args),
+  getAddress: (...args: unknown[]) => getAddressMock(...args),
+  requestAccess: vi.fn(),
+  signTransaction: (...args: unknown[]) => freighterSignTransaction(...args),
+}));
+
+// Minimal stellar-sdk stub so the module resolves without a real SDK install.
+vi.mock("@stellar/stellar-sdk", () => ({
+  Account: class {
+    constructor(public id: string, public sequence: string) {}
+    accountId() { return this.id; }
+    incrementSequenceNumber() {}
+    sequenceNumber() { return this.sequence; }
+  },
+  BASE_FEE: "100",
+  Contract: class { call() { return {}; } },
+  Keypair: { random: () => ({ publicKey: () => "G" }) },
+  Networks: { PUBLIC: "Public", TESTNET: "Test SDF Network ; September 2015" },
+  nativeToScVal: (v: unknown) => v,
+  rpc: {
+    Server: vi.fn().mockImplementation(() => ({
+      getAccount: vi.fn(),
+      simulateTransaction: vi.fn(),
+      sendTransaction: vi.fn(),
+      prepareTransaction: vi.fn(),
+      getTransaction: vi.fn(),
+    })),
+    Api: {
+      isSimulationError: vi.fn().mockReturnValue(false),
+      isSimulationSuccess: vi.fn().mockReturnValue(true),
+      SendTransactionStatus: { ERROR: "ERROR", PENDING: "PENDING", SUCCESS: "SUCCESS" },
+      GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED" },
+    },
+    assembleTransaction: vi.fn(() => ({ build: vi.fn().mockReturnValue({ toXDR: () => "XDR" }) })),
+  },
+  scValToNative: (v: unknown) => v,
+  TransactionBuilder: class {
+    addOperation() { return this; }
+    setTimeout() { return this; }
+    build() { return { toXDR: () => "XDR" }; }
+    static fromXDR() { return {}; }
+  },
+  xdr: {},
+}));
+
+import { signTransaction } from "../lib/stellar";
+
+describe("signTransaction error propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when Freighter returns an error field", async () => {
+    freighterSignTransaction.mockResolvedValue({ error: "User rejected the request." });
+
+    await expect(signTransaction("SOME_XDR")).rejects.toThrow(
+      "User rejected the request.",
+    );
+  });
+
+  it("throws when Freighter rejects with a native Error", async () => {
+    freighterSignTransaction.mockRejectedValue(new Error("Wallet locked"));
+
+    await expect(signTransaction("SOME_XDR")).rejects.toThrow("Wallet locked");
+  });
+
+  it("propagates the error message string intact so the UI can display it", async () => {
+    const msg = "Insufficient balance to cover the transaction fee.";
+    freighterSignTransaction.mockResolvedValue({ error: msg });
+
+    let caught: Error | null = null;
+    try {
+      await signTransaction("SOME_XDR");
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toBe(msg);
+  });
+
+  it("returns the signed XDR string when signing succeeds", async () => {
+    freighterSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+
+    const result = await signTransaction("SOME_XDR");
+
+    expect(result).toBe("SIGNED_XDR");
+  });
+});


### PR DESCRIPTION
## Summary

- **callcontract-send-error.test.ts** (`#308`): `callContract` sendTransaction error path — ERROR status throws, pending state resets (no polling loop entered), FAILED polled status returns `{ status: "ERROR" }`, simulation error short-circuits before sign/send
- **sign-transaction-error.test.ts** (`#307`): `signTransaction` error propagation — Freighter `error` field throws, native Error rejection bubbles, message string passes through intact for UI display, successful signing returns `signedTxXdr`
- **post-job-form-fields.test.tsx** (`#306`): asserts heading, Amount (XLM), Job Description, Token Address, Deadline (optional) fields, and Post Job submit button are all present and enabled when wallet is connected
- **disputes-page-render.test.tsx** (`#305`): heading render, empty state (no disputes), single populated list, multi-dispute list — uses same `vi.mock` utilities and router setup as existing `disputes-page.test.tsx`

## Test results

All 18 tests pass (`vitest run`):
- `callcontract-send-error.test.ts` — 4 tests ✓
- `sign-transaction-error.test.ts` — 4 tests ✓
- `post-job-form-fields.test.tsx` — 6 tests ✓
- `disputes-page-render.test.tsx` — 4 tests ✓

## Test plan

- [ ] `npm test` (or `npx vitest run`) passes in CI
- [ ] No existing tests broken (verified locally against full suite)

closes #305
closes #306
closes #307
closes #308