### PR TITLE
test: add frontend visibility tests for Submit Work, Approve Work, and admin no-wallet guard

### DIFF
--- a/frontend/__tests__/admin-page-no-wallet.test.tsx
+++ b/frontend/__tests__/admin-page-no-wallet.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AdminPage from "@/app/admin/page";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockUseWallet = vi.fn();
+const mockConnectWallet = vi.fn();
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+vi.mock("@/lib/contract", () => ({
+  getNativeToken: vi.fn(),
+  getFees: vi.fn(),
+  getJobCount: vi.fn(),
+  getJob: vi.fn(),
+  withdrawFees: vi.fn(),
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Admin page — no wallet connected", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWallet.mockReturnValue({
+      wallet: null,
+      connectWallet: mockConnectWallet,
+    });
+  });
+
+  it("mounts without crashing when no wallet is connected", () => {
+    expect(() => render(<AdminPage />)).not.toThrow();
+  });
+
+  it("shows the Admin Panel heading", () => {
+    render(<AdminPage />);
+    expect(
+      screen.getByRole("heading", { name: "Admin Panel" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a wallet-connect prompt instead of admin controls", () => {
+    render(<AdminPage />);
+    expect(
+      screen.getByText("Connect your wallet to access admin controls."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Connect Wallet button", () => {
+    render(<AdminPage />);
+    expect(
+      screen.getByRole("button", { name: "Connect Wallet" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the Withdraw Fees button when unauthenticated", () => {
+    render(<AdminPage />);
+    expect(
+      screen.queryByRole("button", { name: /withdraw fees/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the job table when unauthenticated", () => {
+    render(<AdminPage />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/job-detail-approve-work-button.test.tsx
+++ b/frontend/__tests__/job-detail-approve-work-button.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import JobDetailPage from "@/app/job/[id]/page";
+import { ToastProvider } from "@/components/ToastProvider";
+import type { Job } from "@/lib/types";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetJob = vi.fn();
+const mockUseWallet = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+}));
+
+vi.mock("@/lib/contract", () => ({
+  getJob: (...args: unknown[]) => mockGetJob(...args),
+  acceptJob: vi.fn(),
+  submitWork: vi.fn(),
+  approveWork: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    client: "GCLIENT",
+    freelancer: "GFREELANCER",
+    amount: "10000000",
+    description_hash: "abc",
+    status: "SubmittedForReview",
+    created_at: "1710000000",
+    deadline: "0",
+    token: "GTOKEN",
+    revision_count: 0,
+    ...overrides,
+  };
+}
+
+function renderJobPage() {
+  return render(
+    <ToastProvider>
+      <JobDetailPage />
+    </ToastProvider>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Approve Work button visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: connected wallet is the client on a SubmittedForReview job
+    mockUseWallet.mockReturnValue({
+      wallet: "GCLIENT",
+      connectWallet: vi.fn(),
+    });
+  });
+
+  // ── Eligible state ────────────────────────────────────────────────────────
+
+  it("shows Approve Work for the client when work is pending approval", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "SubmittedForReview", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Approve Work" }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  // ── Ineligible statuses ───────────────────────────────────────────────────
+
+  it("hides Approve Work when the job is Open", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Open", freelancer: null }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work when the job is InProgress", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "InProgress", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work when the job is Completed", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Completed", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work when the job is Cancelled", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Cancelled", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work when the job is Disputed", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Disputed", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Role-based exclusions on SubmittedForReview jobs ─────────────────────
+
+  it("hides Approve Work for the freelancer on a SubmittedForReview job", async () => {
+    mockUseWallet.mockReturnValue({ wallet: "GFREELANCER", connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "SubmittedForReview", client: "GCLIENT", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work for a third-party wallet on a SubmittedForReview job", async () => {
+    mockUseWallet.mockReturnValue({ wallet: "GTHIRDPARTY", connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "SubmittedForReview", client: "GCLIENT", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Approve Work when no wallet is connected", async () => {
+    mockUseWallet.mockReturnValue({ wallet: null, connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "SubmittedForReview", client: "GCLIENT" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Approve Work" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/job-detail-submit-work-button.test.tsx
+++ b/frontend/__tests__/job-detail-submit-work-button.test.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import JobDetailPage from "@/app/job/[id]/page";
+import { ToastProvider } from "@/components/ToastProvider";
+import type { Job } from "@/lib/types";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetJob = vi.fn();
+const mockUseWallet = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+}));
+
+vi.mock("@/lib/contract", () => ({
+  getJob: (...args: unknown[]) => mockGetJob(...args),
+  acceptJob: vi.fn(),
+  submitWork: vi.fn(),
+  approveWork: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    client: "GCLIENT",
+    freelancer: "GFREELANCER",
+    amount: "10000000",
+    description_hash: "abc",
+    status: "InProgress",
+    created_at: "1710000000",
+    deadline: "0",
+    token: "GTOKEN",
+    revision_count: 0,
+    ...overrides,
+  };
+}
+
+function renderJobPage() {
+  return render(
+    <ToastProvider>
+      <JobDetailPage />
+    </ToastProvider>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Submit Work button visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: connected wallet is the freelancer on an InProgress job
+    mockUseWallet.mockReturnValue({
+      wallet: "GFREELANCER",
+      connectWallet: vi.fn(),
+    });
+  });
+
+  // ── Eligible state ────────────────────────────────────────────────────────
+
+  it("shows Submit Work for the freelancer on an InProgress job", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "InProgress", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Submit Work" }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  // ── Ineligible statuses ───────────────────────────────────────────────────
+
+  it("hides Submit Work when the job is Open (no freelancer assigned yet)", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Open", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work when the job is SubmittedForReview", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "SubmittedForReview", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work when the job is Completed", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Completed", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work when the job is Cancelled", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Cancelled", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work when the job is Disputed", async () => {
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "Disputed", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Role-based exclusions on InProgress jobs ─────────────────────────────
+
+  it("hides Submit Work for the client on an InProgress job", async () => {
+    mockUseWallet.mockReturnValue({ wallet: "GCLIENT", connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "InProgress", client: "GCLIENT", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    // Approve Work is not available (SubmittedForReview only); Submit Work must not appear either
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work for a third-party wallet on an InProgress job", async () => {
+    mockUseWallet.mockReturnValue({ wallet: "GTHIRDPARTY", connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "InProgress", client: "GCLIENT", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Submit Work when no wallet is connected", async () => {
+    mockUseWallet.mockReturnValue({ wallet: null, connectWallet: vi.fn() });
+    mockGetJob.mockResolvedValue(
+      makeJob({ status: "InProgress", freelancer: "GFREELANCER" }),
+    );
+    renderJobPage();
+
+    await waitFor(() => expect(screen.getByText("Job #1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "Submit Work" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds three test suites covering job-detail action button visibility and the admin page unauthenticated guard, resolving issues FE-TEST-28, FE-TEST-29, and FE-TEST-34.

## Changes

### `frontend/__tests__/job-detail-submit-work-button.test.tsx` (FE-TEST-28)
- Shows **Submit Work** for the assigned freelancer on an `InProgress` job
- Hides it for all other statuses (`Open`, `SubmittedForReview`, `Completed`, `Cancelled`, `Disputed`)
- Hides it for client, third-party wallet, and unauthenticated viewer

### `frontend/__tests__/job-detail-approve-work-button.test.tsx` (FE-TEST-29)
- Shows **Approve Work** for the client when status is `SubmittedForReview`
- Hides it for all other statuses
- Hides it for freelancer, third-party wallet, and unauthenticated viewer

### `frontend/__tests__/admin-page-no-wallet.test.tsx` (FE-TEST-34)
- Mounts admin route without wallet without crashing
- Asserts `Admin Panel` heading and connect-wallet prompt are shown
- Asserts Withdraw Fees button and job table are absent when unauthenticated

## Test approach

All suites follow the existing `job-detail-*` fixture-mock pattern:
- `vi.mock` for `next/navigation`, `@/lib/contract`, and `@/lib/wallet-context`
- `makeJob()` helper with sensible defaults, narrowly overridden per case
- `waitFor` / `findByRole` for async data-load settling before assertions

Closes #298
Closes #299
Closes #304
Closes #388