### PR TITLE
Add XLM to fiat conversion display

### DIFF
--- a/frontend/__tests__/format.test.ts
+++ b/frontend/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toXlm } from "@/lib/format";
+import { formatFiatAmount, formatXlmWithFiat, toXlm } from "@/lib/format";
 
 describe("toXlm", () => {
   it("formats common stroop amounts", () => {
@@ -23,5 +23,23 @@ describe("toXlm", () => {
     const formatted = toXlm("1000000000000000000000");
     expect(/[eE][+-]?\d+/.test(formatted)).toBe(false);
     expect(/\d{2}$/.test(formatted)).toBe(true);
+  });
+});
+
+describe("formatXlmWithFiat", () => {
+  it("shows the selected fiat value next to XLM", () => {
+    const formatted = formatXlmWithFiat(50_000_000, "USD", { USD: 0.12 });
+
+    expect(formatted).toContain("5.00 XLM");
+    expect(formatted).toContain("0.60");
+    expect(formatted).toContain("USD");
+  });
+
+  it("falls back to XLM only when a rate is unavailable", () => {
+    expect(formatXlmWithFiat(50_000_000, "EUR", { USD: 0.12 })).toBe("5.00 XLM");
+  });
+
+  it("formats zero-decimal currencies", () => {
+    expect(formatFiatAmount(125.4, "JPY")).toContain("125");
   });
 });

--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -8,7 +8,16 @@ import StatusPill from "@/components/StatusPill";
 import { useNotifications } from "@/lib/notifications-context";
 import { acceptJob, approveWork, cancelJob, freelancerCancelJob, getDescriptionCid, getJob, submitWork } from "@/lib/contract";
 import { fetchFromIpfs } from "@/lib/ipfs-service";
-import { formatDeadline, toXlm } from "@/lib/format";
+import {
+  fetchXlmFiatRates,
+  formatDeadline,
+  formatXlmFiatRateTooltip,
+  formatXlmWithFiat,
+  getCachedXlmFiatRates,
+  getPreferredFiatCurrency,
+  type FiatCurrency,
+  type XlmFiatRateCache,
+} from "@/lib/format";
 import { getExplorerTxUrl } from "@/lib/stellar";
 import { isConfirmSuppressed, CONFIRM_KEYS } from "@/lib/confirm-prefs";
 import type { Job } from "@/lib/types";
@@ -34,6 +43,8 @@ export default function JobDetailPage() {
   const [invalidId, setInvalidId] = useState(false);
   const [copied, setCopied] = useState(false);
   const [description, setDescription] = useState<string | null>(null);
+  const [fiatCurrency, setFiatCurrency] = useState<FiatCurrency>("USD");
+  const [fiatRates, setFiatRates] = useState<XlmFiatRateCache | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const numericId = Number(id);
@@ -82,6 +93,24 @@ export default function JobDetailPage() {
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
+
+  useEffect(() => {
+    setFiatCurrency(getPreferredFiatCurrency());
+    setFiatRates(getCachedXlmFiatRates());
+    let cancelled = false;
+
+    fetchXlmFiatRates()
+      .then((cache) => {
+        if (!cancelled) setFiatRates(cache);
+      })
+      .catch(() => {
+        if (!cancelled) setFiatRates(getCachedXlmFiatRates());
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!wallet) {
@@ -208,7 +237,8 @@ export default function JobDetailPage() {
 
   // ── Confirm dialog configs ──────────────────────────────────────────────
 
-  const amountXlm = job ? `${toXlm(job.amount)} XLM` : "";
+  const amountXlm = job ? formatXlmWithFiat(job.amount, fiatCurrency, fiatRates?.rates) : "";
+  const fiatTooltip = formatXlmFiatRateTooltip(fiatCurrency, fiatRates?.rates, fiatRates?.fetchedAt);
 
   const DIALOG_CONFIG: Record<
     PendingAction,
@@ -370,8 +400,8 @@ export default function JobDetailPage() {
             "Not assigned"
           )}
         </p>
-        <p>
-          <strong>Amount:</strong> {toXlm(job.amount)} XLM
+        <p title={fiatTooltip}>
+          <strong>Amount:</strong> {formatXlmWithFiat(job.amount, fiatCurrency, fiatRates?.rates)}
         </p>
         <p>
           <strong>Token:</strong>{" "}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,7 +10,19 @@ import JobFilterPanel, { DEFAULT_FILTERS, type JobFilters } from "@/components/J
 import { acceptJob, getDescriptionCid, getJob, getJobCount } from "@/lib/contract";
 import { fetchFromIpfs } from "@/lib/ipfs-service";
 import { useNotifications } from "@/lib/notifications-context";
-import { formatDeadline, toXlm } from "@/lib/format";
+import {
+  FIAT_CURRENCIES,
+  fetchXlmFiatRates,
+  formatDeadline,
+  formatXlmFiatRateTooltip,
+  formatXlmWithFiat,
+  getCachedXlmFiatRates,
+  getPreferredFiatCurrency,
+  savePreferredFiatCurrency,
+  toXlm,
+  type FiatCurrency,
+  type XlmFiatRateCache,
+} from "@/lib/format";
 import {
   clearRecentSearches,
   loadRecentSearches,
@@ -58,6 +70,9 @@ export default function HomePage() {
   const seenJobIdsRef = useRef<Set<number>>(new Set());
   const isInitialLoadRef = useRef(true);
   const [viewMode, setViewMode] = useState<JobsViewMode>("grid");
+  const [fiatCurrency, setFiatCurrency] = useState<FiatCurrency>("USD");
+  const [fiatRates, setFiatRates] = useState<XlmFiatRateCache | null>(null);
+  const [fiatRateError, setFiatRateError] = useState<string | null>(null);
   const [descriptions, setDescriptions] = useState<Record<string, string>>({});
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -75,7 +90,29 @@ export default function HomePage() {
 
   useEffect(() => {
     setViewMode(readViewMode());
+    setFiatCurrency(getPreferredFiatCurrency());
+    setFiatRates(getCachedXlmFiatRates());
   }, []);
+
+  useEffect(() => {
+    savePreferredFiatCurrency(fiatCurrency);
+    let cancelled = false;
+    setFiatRateError(null);
+
+    fetchXlmFiatRates()
+      .then((cache) => {
+        if (!cancelled) setFiatRates(cache);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFiatRateError("Fiat rates are unavailable; showing XLM only where needed.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fiatCurrency]);
 
   useEffect(() => {
     if (viewMode === "grid") {
@@ -332,6 +369,7 @@ export default function HomePage() {
     () => visibleJobs.filter(({ id }) => newJobIds.has(id)).length,
     [newJobIds, visibleJobs],
   );
+  const fiatTooltip = formatXlmFiatRateTooltip(fiatCurrency, fiatRates?.rates, fiatRates?.fetchedAt);
 
   return (
     <section className="space-y-6">
@@ -466,6 +504,24 @@ export default function HomePage() {
         title="Jobs Display"
         description="Default sort is newest first."
       >
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-md border border-slate-200 p-3">
+          <label className="text-sm font-medium text-slate-700">
+            Fiat currency
+            <select
+              value={fiatCurrency}
+              onChange={(event) => setFiatCurrency(event.target.value as FiatCurrency)}
+              className="ml-2 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm"
+              title={fiatTooltip}
+            >
+              {FIAT_CURRENCIES.map((currency) => (
+                <option key={currency} value={currency}>
+                  {currency}
+                </option>
+              ))}
+            </select>
+          </label>
+          {fiatRateError && <p className="text-xs text-amber-700">{fiatRateError}</p>}
+        </div>
         <form onSubmit={handleSearchSubmit} className="space-y-3 rounded-md border border-slate-200 p-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
             <label className="flex-1 text-sm text-slate-600">
@@ -661,11 +717,11 @@ export default function HomePage() {
                       )}
                     </h2>
                   </Link>
-                  <p className="mt-2 flex min-w-0 items-baseline gap-1 text-sm font-bold text-slate-700">
-                    <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap tabular-nums">
-                      {toXlm(job.amount)}
-                    </span>
-                    <span className="shrink-0">XLM</span>
+                  <p
+                    className="mt-2 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold tabular-nums text-slate-700"
+                    title={fiatTooltip}
+                  >
+                    {formatXlmWithFiat(job.amount, fiatCurrency, fiatRates?.rates)}
                   </p>
                   <p className="mt-0.5 truncate font-mono text-xs text-slate-400">
                     Token: {job.token ? `${job.token.slice(0, 8)}...${job.token.slice(-4)}` : "N/A"}

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -24,6 +24,124 @@ export function toXlm(stroops: string | number | bigint): string {
     .padStart(2, "0")}`;
 }
 
+export const FIAT_CURRENCIES = ["USD", "EUR", "GBP", "INR", "JPY"] as const;
+
+export type FiatCurrency = (typeof FIAT_CURRENCIES)[number];
+export type XlmFiatRates = Partial<Record<FiatCurrency, number>>;
+
+export interface XlmFiatRateCache {
+  rates: XlmFiatRates;
+  fetchedAt: number;
+}
+
+const FIAT_RATE_CACHE_KEY = "stellarwork:xlm-fiat-rates";
+const FIAT_CURRENCY_KEY = "stellarwork:preferred-fiat-currency";
+const FIAT_RATE_TTL_MS = 5 * 60 * 1000;
+
+export function isFiatCurrency(value: string): value is FiatCurrency {
+  return FIAT_CURRENCIES.includes(value as FiatCurrency);
+}
+
+export function getPreferredFiatCurrency(): FiatCurrency {
+  if (typeof window === "undefined") return "USD";
+  const stored = window.localStorage.getItem(FIAT_CURRENCY_KEY);
+  return stored && isFiatCurrency(stored) ? stored : "USD";
+}
+
+export function savePreferredFiatCurrency(currency: FiatCurrency): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(FIAT_CURRENCY_KEY, currency);
+}
+
+export function getCachedXlmFiatRates(now = Date.now()): XlmFiatRateCache | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(FIAT_RATE_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as XlmFiatRateCache;
+    if (!parsed || typeof parsed.fetchedAt !== "number" || !parsed.rates) return null;
+    if (now - parsed.fetchedAt > FIAT_RATE_TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchXlmFiatRates(
+  fetcher: typeof fetch = fetch,
+  now = Date.now(),
+): Promise<XlmFiatRateCache> {
+  const cached = getCachedXlmFiatRates(now);
+  if (cached) return cached;
+
+  const response = await fetcher(
+    "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd,eur,gbp,inr,jpy",
+  );
+  if (!response.ok) {
+    throw new Error("Unable to fetch XLM fiat exchange rates.");
+  }
+
+  const data = (await response.json()) as {
+    stellar?: Partial<Record<Lowercase<FiatCurrency>, number>>;
+  };
+  const rates = FIAT_CURRENCIES.reduce<XlmFiatRates>((next, currency) => {
+    const rate = data.stellar?.[currency.toLowerCase() as Lowercase<FiatCurrency>];
+    if (typeof rate === "number" && Number.isFinite(rate)) {
+      next[currency] = rate;
+    }
+    return next;
+  }, {});
+
+  if (Object.keys(rates).length === 0) {
+    throw new Error("XLM fiat exchange rates were unavailable.");
+  }
+
+  const cache = { rates, fetchedAt: now };
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(FIAT_RATE_CACHE_KEY, JSON.stringify(cache));
+  }
+  return cache;
+}
+
+export function formatFiatAmount(amount: number, currency: FiatCurrency): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: currency === "JPY" ? 0 : 2,
+  }).format(amount);
+}
+
+export function formatXlmWithFiat(
+  stroops: string | number | bigint,
+  currency: FiatCurrency,
+  rates?: XlmFiatRates | null,
+): string {
+  const xlm = toXlm(stroops);
+  const rate = rates?.[currency];
+  if (typeof rate !== "number" || !Number.isFinite(rate)) {
+    return `${xlm} XLM`;
+  }
+
+  const xlmAmount = Number(typeof stroops === "bigint" ? stroops : BigInt(stroops)) / 10_000_000;
+  if (!Number.isFinite(xlmAmount)) {
+    return `${xlm} XLM`;
+  }
+
+  return `${xlm} XLM (~${formatFiatAmount(xlmAmount * rate, currency)} ${currency})`;
+}
+
+export function formatXlmFiatRateTooltip(
+  currency: FiatCurrency,
+  rates?: XlmFiatRates | null,
+  fetchedAt?: number,
+): string {
+  const rate = rates?.[currency];
+  if (typeof rate !== "number" || !Number.isFinite(rate)) {
+    return "Fiat conversion unavailable; showing XLM only.";
+  }
+  const timestamp = fetchedAt ? ` Updated ${new Date(fetchedAt).toLocaleString()}.` : "";
+  return `1 XLM = ${formatFiatAmount(rate, currency)} ${currency}.${timestamp}`;
+}
 function formatRelativeInterval(deltaMs: number): string {
   const absSeconds = Math.max(1, Math.round(Math.abs(deltaMs) / 1000));
   const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [


### PR DESCRIPTION
Closes #415
Closes #416 
Closes #417
Closes #418

## Summary
- Added shared XLM-to-fiat helpers for USD, EUR, GBP, INR, and JPY.
- Fetches Stellar/XLM exchange rates from CoinGecko and caches them for 5 minutes in local storage.
- Adds a fiat currency selector to the jobs list so users can choose the display currency.
- Shows job card amounts as XLM with an approximate fiat value when rates are available.
- Reuses the selected currency and cached rate on the job detail page, including confirmation impact text.
- Falls back to XLM-only display when exchange rates cannot be fetched.
- Adds formatter coverage for fiat conversion and fallback behavior.
