### PR TITLE
Add recent searches dropdown

### DIFF
--- a/frontend/__tests__/recent-searches.test.ts
+++ b/frontend/__tests__/recent-searches.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_RECENT_SEARCHES,
+  clearRecentSearches,
+  loadRecentSearches,
+  removeRecentSearch,
+  saveRecentSearches,
+  updateRecentSearches,
+} from "@/lib/recent-searches";
+
+describe("recent search helpers", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", window);
+    localStorage.clear();
+  });
+
+  it("stores the last ten unique searches with the newest first", () => {
+    const searches = Array.from({ length: 12 }, (_, index) => `term-${index + 1}`).reduce(
+      (current, term) => updateRecentSearches(current, term),
+      [] as string[],
+    );
+
+    expect(searches).toHaveLength(MAX_RECENT_SEARCHES);
+    expect(searches[0]).toBe("term-12");
+    expect(searches).not.toContain("term-1");
+  });
+
+  it("moves an existing search to the front instead of duplicating it", () => {
+    const searches = updateRecentSearches(["design", "frontend"], "Frontend");
+
+    expect(searches).toEqual(["Frontend", "design"]);
+  });
+
+  it("removes an individual recent search", () => {
+    expect(removeRecentSearch(["design", "frontend", "contract"], "frontend")).toEqual([
+      "design",
+      "contract",
+    ]);
+  });
+
+  it("loads, saves, and clears persisted searches", () => {
+    saveRecentSearches(["one", "two"]);
+    expect(loadRecentSearches()).toEqual(["one", "two"]);
+
+    clearRecentSearches();
+    expect(loadRecentSearches()).toEqual([]);
+  });
+});

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -536,7 +536,7 @@ export default function HomePage() {
             <div
               className="relative flex-1 text-sm text-slate-600"
               onBlur={(event) => {
-                if (!event.currentTarget.contains(event.relatedTarget)) {
+                if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
                   setRecentSearchesOpen(false);
                 }
               }}
@@ -579,7 +579,19 @@ export default function HomePage() {
                           onClick={() => handleRecentSearchSelect(term)}
                           className="flex min-w-0 flex-1 items-center gap-2 text-left"
                         >
-                          <span aria-hidden="true" className="text-slate-400">clock</span>
+                                                    <svg
+                            aria-hidden="true"
+                            viewBox="0 0 24 24"
+                            className="h-4 w-4 shrink-0 text-slate-400"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <circle cx="12" cy="12" r="9" />
+                            <path d="M12 7v5l3 2" />
+                          </svg>
                           <span className="truncate">{term}</span>
                         </button>
                         <button

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -26,6 +26,7 @@ import {
 import {
   clearRecentSearches,
   loadRecentSearches,
+  removeRecentSearch,
   saveRecentSearches,
   updateRecentSearches,
 } from "@/lib/recent-searches";
@@ -64,6 +65,7 @@ export default function HomePage() {
   const [bookmarkedIds, setBookmarkedIds] = useState<number[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [recentSearches, setRecentSearches] = useState<string[] | null>(null);
+  const [recentSearchesOpen, setRecentSearchesOpen] = useState(false);
   const [resultsAnnouncement, setResultsAnnouncement] = useState("");
   const [lastAnnouncedSignature, setLastAnnouncedSignature] = useState("");
   const [newJobIds, setNewJobIds] = useState<Set<number>>(() => new Set());
@@ -346,13 +348,19 @@ export default function HomePage() {
     const term = searchTerm.trim();
     if (!term) return;
     setRecentSearches((current) => updateRecentSearches(current ?? [], term));
+    setRecentSearchesOpen(false);
     setPage(1);
   };
 
   const handleRecentSearchSelect = (term: string) => {
     setSearchTerm(term);
     setRecentSearches((current) => updateRecentSearches(current ?? [], term));
+    setRecentSearchesOpen(false);
     setPage(1);
+  };
+
+  const handleRemoveRecentSearch = (term: string) => {
+    setRecentSearches((current) => removeRecentSearch(current ?? [], term));
   };
 
   const handleClearSearch = () => {
@@ -362,6 +370,7 @@ export default function HomePage() {
 
   const handleClearSearchHistory = () => {
     setRecentSearches([]);
+    setRecentSearchesOpen(false);
     clearRecentSearches();
   };
 
@@ -524,19 +533,76 @@ export default function HomePage() {
         </div>
         <form onSubmit={handleSearchSubmit} className="space-y-3 rounded-md border border-slate-200 p-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
-            <label className="flex-1 text-sm text-slate-600">
-              <span className="block font-medium text-slate-700">Search jobs</span>
+            <div
+              className="relative flex-1 text-sm text-slate-600"
+              onBlur={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  setRecentSearchesOpen(false);
+                }
+              }}
+            >
+              <label htmlFor="job-search" className="block font-medium text-slate-700">
+                Search jobs
+              </label>
               <input
+                id="job-search"
                 type="search"
                 value={searchTerm}
                 onChange={(event) => {
                   setSearchTerm(event.target.value);
                   setPage(1);
                 }}
+                onFocus={() => setRecentSearchesOpen((recentSearches?.length ?? 0) > 0)}
                 placeholder="Search by ID, description, wallet, or amount"
                 className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2"
+                aria-controls="recent-searches-listbox"
+                aria-expanded={recentSearchesOpen}
+                aria-haspopup="listbox"
               />
-            </label>
+              {recentSearchesOpen && (recentSearches?.length ?? 0) > 0 && (
+                <div className="absolute z-20 mt-2 w-full rounded-md border border-slate-200 bg-white p-2 shadow-lg">
+                  <div
+                    id="recent-searches-listbox"
+                    role="listbox"
+                    aria-label="Recent searches"
+                    className="space-y-1"
+                  >
+                    {(recentSearches ?? []).map((term) => (
+                      <div
+                        key={term}
+                        role="option"
+                        aria-selected={searchTerm.trim().toLowerCase() === term.toLowerCase()}
+                        className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => handleRecentSearchSelect(term)}
+                          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                        >
+                          <span aria-hidden="true" className="text-slate-400">clock</span>
+                          <span className="truncate">{term}</span>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveRecentSearch(term)}
+                          className="rounded px-2 py-1 text-xs font-medium text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                          aria-label={`Remove ${term} from recent searches`}
+                        >
+                          X
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleClearSearchHistory}
+                    className="mt-2 w-full border-t border-slate-100 pt-2 text-left text-xs font-medium text-slate-600 hover:text-slate-900"
+                  >
+                    Clear history
+                  </button>
+                </div>
+              )}
+            </div>
             <div className="flex flex-wrap gap-2">
               <button
                 type="submit"
@@ -555,38 +621,6 @@ export default function HomePage() {
               </button>
             </div>
           </div>
-          {(recentSearches?.length ?? 0) > 0 && (
-            <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Recent searches
-                </p>
-                <button
-                  type="button"
-                  onClick={handleClearSearchHistory}
-                  className="text-xs font-medium text-slate-600 hover:text-slate-900"
-                >
-                  Clear history
-                </button>
-              </div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {(recentSearches ?? []).map((term) => (
-                  <button
-                    key={term}
-                    type="button"
-                    onClick={() => handleRecentSearchSelect(term)}
-                    className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
-                      searchTerm.trim().toLowerCase() === term.toLowerCase()
-                        ? "border-slate-900 bg-slate-900 text-white"
-                        : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
-                    }`}
-                  >
-                    {term}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
         </form>
 
         <fieldset className="space-y-3 rounded-md border border-slate-200 p-3">

--- a/frontend/lib/recent-searches.ts
+++ b/frontend/lib/recent-searches.ts
@@ -1,7 +1,7 @@
 "use client";
 
 const RECENT_SEARCHES_STORAGE_KEY = "stellarwork:recent-searches";
-const MAX_RECENT_SEARCHES = 5;
+export const MAX_RECENT_SEARCHES = 10;
 
 function normalizeTerm(term: string): string {
   return term.trim();
@@ -20,6 +20,9 @@ export function loadRecentSearches(): string[] {
     return parsed
       .map((entry) => (typeof entry === "string" ? normalizeTerm(entry) : ""))
       .filter((entry): entry is string => entry.length > 0)
+      .filter((entry, index, entries) =>
+        entries.findIndex((candidate) => candidate.toLowerCase() === entry.toLowerCase()) === index,
+      )
       .slice(0, MAX_RECENT_SEARCHES);
   } catch {
     return [];
@@ -28,7 +31,10 @@ export function loadRecentSearches(): string[] {
 
 export function saveRecentSearches(searches: string[]): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(RECENT_SEARCHES_STORAGE_KEY, JSON.stringify(searches));
+  localStorage.setItem(
+    RECENT_SEARCHES_STORAGE_KEY,
+    JSON.stringify(searches.map(normalizeTerm).filter(Boolean).slice(0, MAX_RECENT_SEARCHES)),
+  );
 }
 
 export function updateRecentSearches(searches: string[], term: string): string[] {
@@ -43,6 +49,11 @@ export function updateRecentSearches(searches: string[], term: string): string[]
   ];
 
   return next.slice(0, MAX_RECENT_SEARCHES);
+}
+
+export function removeRecentSearch(searches: string[], term: string): string[] {
+  const normalized = normalizeTerm(term).toLowerCase();
+  return searches.filter((entry) => entry.toLowerCase() !== normalized);
 }
 
 export function clearRecentSearches(): void {


### PR DESCRIPTION
Closes #468
Closes #467 
Closes #466
Closes #465

## Summary
This PR adds the requested recent-search workflow to the jobs search bar. The app already had a small localStorage-backed recent-search helper, but the UI was rendered as a static chip section below the search form and the history was capped at five items. This change turns that into an accessible dropdown that appears when the search input is focused.

## Changes
- Expands stored recent searches from 5 to 10 entries.
- Keeps recent searches unique by case-insensitive term matching.
- Moves repeated searches back to the top instead of duplicating them.
- Adds a focused recent-search dropdown attached to the search input.
- Uses role=listbox and role=option for the dropdown/options.
- Adds aria-controls, aria-expanded, and aria-haspopup=listbox to the search input.
- Adds a decorative clock SVG beside each recent search entry.
- Lets users click a recent search to reapply the term and close the dropdown.
- Adds an individual remove button for each recent search entry.
- Keeps the existing Clear history behavior, now inside the dropdown footer.
- Adds helper coverage for updating, deduplicating, removing, saving, loading, and clearing recent searches.

## User Experience
Users can now focus the search field and immediately see their recent queries instead of retyping common job keywords, wallet snippets, descriptions, or amount searches. Selecting a previous search restores it and triggers the same filtered search flow already used by the page.

The dropdown stays out of the way when there is no history, closes after a search is selected, and supports both full history clearing and removing a single stale entry.

## Testing
Not run locally.

Added coverage:
- frontend/__tests__/recent-searches.test.ts
- Verifies max history length is 10.
- Verifies repeated terms are deduplicated and moved to the top.
- Verifies individual removal.
- Verifies save/load/clear persistence helpers.