### PR TITLE
feat: two-step ownership transfer, SEO metadata, custom error pages, settings page

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -133,6 +133,9 @@ pub enum DataKey {
     DisputeRaiser(u64),
     /// Fee exemption status for an address.
     FeeExempted(Address),
+    // Issue #460: two-step ownership transfer
+    /// Address nominated to become the next admin (cleared on accept or cancel).
+    PendingAdmin,
 }
 
 #[contracterror]
@@ -169,6 +172,9 @@ pub enum Error {
     SelfReferralNotAllowed = 26,
     DeadlineNotExtendable = 27,
     NoFreelancerAssigned = 28,
+    // Issue #460: two-step ownership transfer
+    NoPendingTransfer = 29,
+    NotPendingAdmin = 30,
 }
 
 #[contract]
@@ -912,6 +918,93 @@ impl EscrowContract {
         bump_instance_ttl(&e);
         e.events()
             .publish((Symbol::new(&e, "admin_transferred"),), (caller, new_admin));
+    }
+
+    // ── Issue #460: two-step ownership transfer ──────────────────────────────
+
+    /// Step 1: nominate `new_admin` as the pending admin.
+    ///
+    /// Only the current admin may call this. Emits `OwnershipTransferStarted`.
+    /// The transfer is not final until the nominee calls `accept_ownership`.
+    pub fn transfer_ownership(e: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        let current_admin = load_admin(&e);
+        if admin != current_admin {
+            panic_with_error!(&e, Error::UnauthorizedAdmin);
+        }
+        e.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        bump_instance_ttl(&e);
+        e.events().publish(
+            (Symbol::new(&e, "ownership_transfer_started"),),
+            (admin, new_admin),
+        );
+    }
+
+    /// Step 2: the nominated address accepts and becomes the new admin.
+    ///
+    /// Only the pending admin may call this. Clears `PendingAdmin` and emits
+    /// `OwnershipTransferred`.
+    pub fn accept_ownership(e: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending: Option<Address> = e
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin);
+        let pending_admin = match pending {
+            Some(a) => a,
+            None => panic_with_error!(&e, Error::NoPendingTransfer),
+        };
+        if new_admin != pending_admin {
+            panic_with_error!(&e, Error::NotPendingAdmin);
+        }
+        let old_admin = load_admin(&e);
+        e.storage()
+            .instance()
+            .set(&DataKey::Admin, &new_admin);
+        e.storage()
+            .instance()
+            .remove(&DataKey::PendingAdmin);
+        bump_instance_ttl(&e);
+        e.events().publish(
+            (Symbol::new(&e, "ownership_transferred"),),
+            (old_admin, new_admin),
+        );
+    }
+
+    /// Abort a pending ownership transfer.
+    ///
+    /// Only the current admin may cancel. Clears `PendingAdmin` and emits
+    /// `OwnershipTransferCancelled`.
+    pub fn cancel_ownership_transfer(e: Env, admin: Address) {
+        admin.require_auth();
+        let current_admin = load_admin(&e);
+        if admin != current_admin {
+            panic_with_error!(&e, Error::UnauthorizedAdmin);
+        }
+        let pending: Option<Address> = e
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin);
+        if pending.is_none() {
+            panic_with_error!(&e, Error::NoPendingTransfer);
+        }
+        e.storage()
+            .instance()
+            .remove(&DataKey::PendingAdmin);
+        bump_instance_ttl(&e);
+        e.events().publish(
+            (Symbol::new(&e, "ownership_transfer_cancelled"),),
+            (admin,),
+        );
+    }
+
+    /// Returns the nominated pending admin, or `None` if no transfer is in progress.
+    pub fn get_pending_admin(e: Env) -> Option<Address> {
+        e.storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
     }
 
     pub fn get_job_count(e: Env) -> u64 {
@@ -7630,5 +7723,92 @@ mod test {
             events_after > events_before,
             "extend_deadline must emit at least one event"
         );
+    }
+
+    // ── Issue #460: two-step ownership transfer ──────────────────────────────
+
+    #[test]
+    fn transfer_ownership_sets_pending_admin() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        assert_eq!(client.get_pending_admin(), None);
+        client.transfer_ownership(&admin, &new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin));
+        // Admin unchanged until accepted
+        assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    fn accept_ownership_promotes_pending_and_clears_slot() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        client.transfer_ownership(&admin, &new_admin);
+        client.accept_ownership(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    fn cancel_ownership_transfer_clears_pending() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        client.transfer_ownership(&admin, &new_admin);
+        client.cancel_ownership_transfer(&admin);
+        assert_eq!(client.get_pending_admin(), None);
+        // Admin unchanged
+        assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #29)")]
+    fn accept_ownership_panics_when_no_pending_transfer() {
+        let (env, client, _, _, _, _) = setup();
+        let stranger = Address::generate(&env);
+        client.accept_ownership(&stranger);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #30)")]
+    fn accept_ownership_panics_for_wrong_address() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        client.transfer_ownership(&admin, &new_admin);
+        client.accept_ownership(&stranger);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #29)")]
+    fn cancel_ownership_transfer_panics_when_no_pending_transfer() {
+        let (_, client, admin, _, _, _) = setup();
+        client.cancel_ownership_transfer(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #13)")]
+    fn transfer_ownership_rejects_non_admin() {
+        let (env, client, _, _, _, _) = setup();
+        let stranger = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        client.transfer_ownership(&stranger, &new_admin);
+    }
+
+    #[test]
+    fn transfer_ownership_emits_started_event() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        let events_before = env.events().all().len();
+        client.transfer_ownership(&admin, &new_admin);
+        assert!(env.events().all().len() > events_before);
+    }
+
+    #[test]
+    fn accept_ownership_emits_transferred_event() {
+        let (env, client, admin, _, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        client.transfer_ownership(&admin, &new_admin);
+        let events_before = env.events().all().len();
+        client.accept_ownership(&new_admin);
+        assert!(env.events().all().len() > events_before);
     }
 }

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,20 +1,74 @@
 "use client";
 
-import RouteErrorState from "@/components/RouteErrorState";
+import Link from "next/link";
+import { useEffect, useId, useState } from "react";
 
 export default function GlobalError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const uid = useId();
+  const [errorId] = useState(() => {
+    const ts = Date.now().toString(36).toUpperCase();
+    const rand = Math.random().toString(36).slice(2, 6).toUpperCase();
+    return `ERR-${ts}-${rand}`;
+  });
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error("[StellarWork]", errorId, error);
+  }, [error, errorId]);
+
   return (
-    <RouteErrorState
-      title="Something went wrong"
-      description="The page failed to load. You can retry or return to the home feed."
-      backHref="/"
-      backLabel="Home"
-      onRetry={reset}
-    />
+    <section
+      className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-8 px-6 py-16 text-center"
+      aria-labelledby={`${uid}-heading`}
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-24 w-24 items-center justify-center rounded-full bg-rose-50 dark:bg-rose-900/20"
+      >
+        <span className="text-5xl select-none">⚠️</span>
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-widest text-rose-500">
+          Error
+        </p>
+        <h1
+          id={`${uid}-heading`}
+          className="text-3xl font-bold text-slate-900 dark:text-slate-100"
+        >
+          Something went wrong
+        </h1>
+        <p className="max-w-md text-base text-slate-500 dark:text-slate-400">
+          An unexpected error occurred. You can try again or return home. If the
+          problem persists, contact support with the reference code below.
+        </p>
+        <p className="mt-1 font-mono text-xs text-slate-400 dark:text-slate-500">
+          Ref: {errorId}
+          {error.digest ? ` · digest: ${error.digest}` : ""}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="rounded-lg border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+        >
+          Go home
+        </Link>
+      </div>
+    </section>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,6 +13,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import CommandPalette from "@/components/CommandPalette";
 import OnboardingProvider from "@/components/OnboardingProvider";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
+import JsonLd from "@/components/JsonLd";
 import Link from "next/link";
 import "./globals.css";
 
@@ -32,9 +33,66 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://stellarwork.app";
+
 export const metadata: Metadata = {
-  title: "StellarWork",
-  description: "Decentralized escrow freelance marketplace on Stellar",
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: "StellarWork — Decentralized Freelance Marketplace on Stellar",
+    template: "%s | StellarWork",
+  },
+  description:
+    "StellarWork is a decentralized escrow freelance marketplace built on Stellar. Find jobs, hire talent, and get paid trustlessly with smart-contract escrow.",
+  keywords: [
+    "freelance",
+    "Stellar",
+    "blockchain",
+    "escrow",
+    "decentralized",
+    "crypto jobs",
+    "smart contracts",
+    "Web3 freelance",
+  ],
+  authors: [{ name: "StellarWork" }],
+  creator: "StellarWork",
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: BASE_URL,
+    siteName: "StellarWork",
+    title: "StellarWork — Decentralized Freelance Marketplace on Stellar",
+    description:
+      "Hire or work as a freelancer with trustless smart-contract escrow on the Stellar network.",
+    images: [
+      {
+        url: "/og-default.png",
+        width: 1200,
+        height: 630,
+        alt: "StellarWork — Decentralized Freelance Marketplace",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "StellarWork — Decentralized Freelance Marketplace on Stellar",
+    description:
+      "Hire or work as a freelancer with trustless smart-contract escrow on the Stellar network.",
+    images: ["/og-default.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  alternates: {
+    canonical: BASE_URL,
+  },
 };
 
 export default async function RootLayout({
@@ -52,6 +110,21 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+        <JsonLd
+          data={{
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "StellarWork",
+            url: BASE_URL,
+            description:
+              "Decentralized escrow freelance marketplace built on the Stellar network.",
+            potentialAction: {
+              "@type": "SearchAction",
+              target: `${BASE_URL}/?q={search_term_string}`,
+              "query-input": "required name=search_term_string",
+            },
+          }}
+        />
         <NextIntlClientProvider messages={messages} locale={locale}>
         <ThemeProvider>
         <WalletProvider>

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "404 — Page Not Found",
+  description: "The page you were looking for does not exist.",
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <section
+      className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-8 px-6 py-16 text-center"
+      aria-labelledby="not-found-heading"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-24 w-24 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800"
+      >
+        <span className="text-5xl select-none">🔭</span>
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">
+          404
+        </p>
+        <h1
+          id="not-found-heading"
+          className="text-3xl font-bold text-slate-900 dark:text-slate-100"
+        >
+          Page not found
+        </h1>
+        <p className="max-w-md text-base text-slate-500 dark:text-slate-400">
+          We couldn&apos;t find what you were looking for. The page may have
+          moved, been removed, or never existed.
+        </p>
+      </div>
+
+      <nav
+        aria-label="Recovery options"
+        className="flex flex-wrap justify-center gap-3"
+      >
+        <Link
+          href="/"
+          className="rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300"
+        >
+          Go home
+        </Link>
+        <Link
+          href="/?status=Open"
+          className="rounded-lg border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+        >
+          Browse jobs
+        </Link>
+      </nav>
+    </section>
+  );
+}

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://stellarwork.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin/", "/api/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import SettingsClient from "./settings-client";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Manage your display, notification, privacy, and account preferences.",
+  robots: { index: false, follow: false },
+};
+
+export default function SettingsPage() {
+  return <SettingsClient />;
+}

--- a/frontend/app/settings/settings-client.tsx
+++ b/frontend/app/settings/settings-client.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useTheme } from "@/components/ThemeProvider";
+import { useWallet } from "@/lib/wallet-context";
+import {
+  FIAT_CURRENCIES,
+  getPreferredFiatCurrency,
+  savePreferredFiatCurrency,
+  type FiatCurrency,
+} from "@/lib/format";
+import {
+  useNotifications,
+  getEventLabel,
+} from "@/lib/notifications-context";
+import type { NotificationEvent } from "@/lib/types";
+import { getNetwork } from "@/lib/stellar";
+import { useCallback, useEffect, useId, useState } from "react";
+
+const NOTIFICATION_EVENTS: NotificationEvent[] = [
+  "job_accepted",
+  "work_submitted",
+  "work_approved",
+  "job_cancelled",
+  "dispute_raised",
+  "dispute_resolved",
+];
+
+const PROFILE_VISIBILITY_KEY = "stellarwork:settings:profile_visible";
+const SHOW_EMAIL_KEY = "stellarwork:settings:show_email";
+
+function readBool(key: string, defaultValue: boolean): boolean {
+  if (typeof window === "undefined") return defaultValue;
+  const v = localStorage.getItem(key);
+  if (v === null) return defaultValue;
+  return v === "true";
+}
+
+function Toggle({
+  id,
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  id: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  description?: string;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex cursor-pointer items-center justify-between gap-4"
+    >
+      <span className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium text-slate-800 dark:text-slate-200">
+          {label}
+        </span>
+        {description && (
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            {description}
+          </span>
+        )}
+      </span>
+      <button
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        type="button"
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+          checked
+            ? "bg-blue-600"
+            : "bg-slate-200 dark:bg-slate-700"
+        }`}
+      >
+        <span
+          aria-hidden="true"
+          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-md ring-0 transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </label>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 className="mb-4 text-base font-semibold text-slate-900 dark:text-slate-100">
+        {title}
+      </h2>
+      <div className="space-y-4">{children}</div>
+    </section>
+  );
+}
+
+export default function SettingsClient() {
+  const { theme, setTheme } = useTheme();
+  const { wallet } = useWallet();
+  const { preferences, setPreference } = useNotifications();
+  const network = getNetwork();
+  const themeId = useId();
+  const currencyId = useId();
+
+  const [currency, setCurrency] = useState<FiatCurrency>("USD");
+  const [profileVisible, setProfileVisible] = useState(true);
+  const [showEmail, setShowEmail] = useState(false);
+
+  useEffect(() => {
+    setCurrency(getPreferredFiatCurrency());
+    setProfileVisible(readBool(PROFILE_VISIBILITY_KEY, true));
+    setShowEmail(readBool(SHOW_EMAIL_KEY, false));
+  }, []);
+
+  const handleCurrencyChange = useCallback((c: FiatCurrency) => {
+    setCurrency(c);
+    savePreferredFiatCurrency(c);
+  }, []);
+
+  const handleProfileVisible = useCallback((v: boolean) => {
+    setProfileVisible(v);
+    localStorage.setItem(PROFILE_VISIBILITY_KEY, String(v));
+  }, []);
+
+  const handleShowEmail = useCallback((v: boolean) => {
+    setShowEmail(v);
+    localStorage.setItem(SHOW_EMAIL_KEY, String(v));
+  }, []);
+
+  const resetDisplay = useCallback(() => {
+    setTheme("system");
+    handleCurrencyChange("USD");
+  }, [setTheme, handleCurrencyChange]);
+
+  const resetNotifications = useCallback(() => {
+    for (const event of NOTIFICATION_EVENTS) {
+      setPreference(event, true);
+    }
+  }, [setPreference]);
+
+  const resetPrivacy = useCallback(() => {
+    handleProfileVisible(true);
+    handleShowEmail(false);
+  }, [handleProfileVisible, handleShowEmail]);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 py-2">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          Settings
+        </h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Preferences are saved automatically and persist across sessions.
+        </p>
+      </div>
+
+      {/* Display */}
+      <Section title="Display">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor={themeId}
+            className="text-sm font-medium text-slate-800 dark:text-slate-200"
+          >
+            Theme
+          </label>
+          <select
+            id={themeId}
+            value={theme}
+            onChange={(e) =>
+              setTheme(e.target.value as "light" | "dark" | "system")
+            }
+            className="w-48 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+          >
+            <option value="system">System default</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor={currencyId}
+            className="text-sm font-medium text-slate-800 dark:text-slate-200"
+          >
+            Fiat currency
+          </label>
+          <select
+            id={currencyId}
+            value={currency}
+            onChange={(e) => handleCurrencyChange(e.target.value as FiatCurrency)}
+            className="w-48 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+          >
+            {FIAT_CURRENCIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Used for XLM fiat equivalents shown across the app.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={resetDisplay}
+          className="text-xs text-slate-400 underline hover:text-slate-600 dark:hover:text-slate-300"
+        >
+          Reset to defaults
+        </button>
+      </Section>
+
+      {/* Notifications */}
+      <Section title="Notifications">
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Choose which in-app events trigger a notification.
+        </p>
+        {NOTIFICATION_EVENTS.map((event) => (
+          <Toggle
+            key={event}
+            id={`notif-${event}`}
+            checked={preferences[event]}
+            onChange={(v) => setPreference(event, v)}
+            label={getEventLabel(event)}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={resetNotifications}
+          className="text-xs text-slate-400 underline hover:text-slate-600 dark:hover:text-slate-300"
+        >
+          Enable all notifications
+        </button>
+      </Section>
+
+      {/* Privacy */}
+      <Section title="Privacy">
+        <Toggle
+          id="privacy-profile-visible"
+          checked={profileVisible}
+          onChange={handleProfileVisible}
+          label="Public profile"
+          description="Allow others to view your on-chain activity."
+        />
+        <Toggle
+          id="privacy-show-email"
+          checked={showEmail}
+          onChange={handleShowEmail}
+          label="Show email on profile"
+          description="Display your email address on your public profile page."
+        />
+        <button
+          type="button"
+          onClick={resetPrivacy}
+          className="text-xs text-slate-400 underline hover:text-slate-600 dark:hover:text-slate-300"
+        >
+          Reset to defaults
+        </button>
+      </Section>
+
+      {/* Account */}
+      <Section title="Account">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+            Connected wallet
+          </p>
+          {wallet ? (
+            <p className="break-all font-mono text-xs text-slate-600 dark:text-slate-400">
+              {wallet}
+            </p>
+          ) : (
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              No wallet connected.
+            </p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+            Network
+          </p>
+          <p className="text-xs capitalize text-slate-600 dark:text-slate-400">
+            {network}
+          </p>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://stellarwork.app";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "always",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/post-job`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/dashboard`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+  ];
+}

--- a/frontend/components/JsonLd.tsx
+++ b/frontend/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+type JsonLdProps = {
+  data: Record<string, unknown>;
+};
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **#460** — Two-step ownership transfer for the escrow contract. Added `DataKey::PendingAdmin`, error codes `NoPendingTransfer = 29` and `NotPendingAdmin = 30`, and four new entrypoints: `transfer_ownership` (sets pending admin, emits `ownership_transfer_started`), `accept_ownership` (promotes pending to admin, emits `ownership_transferred`), `cancel_ownership_transfer` (admin aborts, emits `ownership_transfer_cancelled`), and `get_pending_admin`. Includes 9 unit tests covering the full lifecycle and all failure paths.

- **#461** — Landing page SEO and OG metadata. Expanded `metadata` in `app/layout.tsx` with full `openGraph`, `twitter`, `robots`, `keywords`, `alternates.canonical`, and a `template` title. Added `app/sitemap.ts` (Next.js `MetadataRoute.Sitemap`) and `app/robots.ts`. Added `components/JsonLd.tsx` and injected a `WebSite` + `SearchAction` JSON-LD block into the root layout.

- **#462** — Custom branded error pages. Created `app/not-found.tsx` (404): icon, heading, "Go home" + "Browse jobs" CTAs, accessible heading hierarchy. Replaced `app/error.tsx` (runtime/500): icon, auto-generated `ERR-<timestamp>-<rand>` reference code shown to the user and logged to console, Retry + Go home buttons, full dark-mode support.

- **#464** — User settings page at `/settings`. Server page (`settings/page.tsx`) exports `Metadata`; client component (`settings-client.tsx`) renders four sections: **Display** (theme via `useTheme`, fiat currency via `savePreferredFiatCurrency`), **Notifications** (all `NotificationEvent` toggles via `useNotifications`), **Privacy** (profile visibility + show email, persisted in `localStorage`), **Account** (connected wallet address + network, read-only). Each section has a reset-to-defaults link; all preferences instant-save.

Closes #460
Closes #461
Closes #462
Closes #464