### PR TITLE
feat: SC-81 dashboard stats, FE-109 voice nav, DOC-30 OpenAPI spec, FE-110 footer version

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -86,6 +86,22 @@ pub struct MilestoneInput {
 ///    5_000 → 50 / 50 split (fee deducted from total before splitting)
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DashboardStats {
+    pub total_jobs: u64,
+    pub open_jobs: u64,
+    /// Jobs in InProgress or SubmittedForReview status.
+    pub active_jobs: u64,
+    pub completed_jobs: u64,
+    pub cancelled_jobs: u64,
+    pub disputed_jobs: u64,
+    /// Fees accrued in the native token (in stroops).
+    pub total_fees_accrued: i128,
+    /// Sum of all job amounts ever posted (in stroops).
+    pub total_volume: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FeeTier {
     pub min_amount: i128,
     pub fee_bps: i128,
@@ -1609,6 +1625,63 @@ impl EscrowContract {
             }
         }
         jobs
+    }
+
+    /// Returns all key platform metrics in a single contract call.
+    /// Requires admin authentication to prevent data leakage.
+    pub fn get_dashboard_stats(e: Env, admin: Address) -> DashboardStats {
+        admin.require_auth();
+        let current_admin = load_admin(&e);
+        if admin != current_admin {
+            panic_with_error!(&e, Error::UnauthorizedAdmin);
+        }
+
+        let total_jobs = get_jobs_count(&e);
+        let mut open_jobs: u64 = 0;
+        let mut active_jobs: u64 = 0;
+        let mut completed_jobs: u64 = 0;
+        let mut cancelled_jobs: u64 = 0;
+        let mut disputed_jobs: u64 = 0;
+        let mut total_volume: i128 = 0;
+
+        let all_ids: Vec<u64> = e
+            .storage()
+            .persistent()
+            .get(&DataKey::AllJobIds)
+            .unwrap_or(Vec::new(&e));
+
+        for i in 0..all_ids.len() {
+            if let Some(job_id) = all_ids.get(i) {
+                if let Some(job) = e
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, Job>(&DataKey::Job(job_id))
+                {
+                    total_volume = checked_add(&e, total_volume, job.amount);
+                    match job.status {
+                        JobStatus::Open => open_jobs += 1,
+                        JobStatus::InProgress | JobStatus::SubmittedForReview => active_jobs += 1,
+                        JobStatus::Completed => completed_jobs += 1,
+                        JobStatus::Cancelled => cancelled_jobs += 1,
+                        JobStatus::Disputed => disputed_jobs += 1,
+                    }
+                }
+            }
+        }
+
+        let native_token = load_native_token(&e);
+        let total_fees_accrued = get_token_fees(&e, &native_token);
+
+        DashboardStats {
+            total_jobs,
+            open_jobs,
+            active_jobs,
+            completed_jobs,
+            cancelled_jobs,
+            disputed_jobs,
+            total_fees_accrued,
+            total_volume,
+        }
     }
 }
 
@@ -8125,5 +8198,88 @@ mod test {
         let events_before = env.events().all().len();
         client.accept_ownership(&new_admin);
         assert!(env.events().all().len() > events_before);
+    }
+
+    // ── Issue SC-81: get_dashboard_stats tests ────────────────────────────
+
+    #[test]
+    fn dashboard_stats_empty_platform() {
+        let (_, client, admin, _, _, _) = setup();
+        let stats = client.get_dashboard_stats(&admin);
+        assert_eq!(stats.total_jobs, 0);
+        assert_eq!(stats.open_jobs, 0);
+        assert_eq!(stats.active_jobs, 0);
+        assert_eq!(stats.completed_jobs, 0);
+        assert_eq!(stats.cancelled_jobs, 0);
+        assert_eq!(stats.disputed_jobs, 0);
+        assert_eq!(stats.total_fees_accrued, 0);
+        assert_eq!(stats.total_volume, 0);
+    }
+
+    #[test]
+    fn dashboard_stats_counts_open_job() {
+        let (env, client, admin, user, _, native_token) = setup();
+        client.post_job(&user, &1_000_000i128, &hash(&env), &32u32, &0u64, &native_token);
+        let stats = client.get_dashboard_stats(&admin);
+        assert_eq!(stats.total_jobs, 1);
+        assert_eq!(stats.open_jobs, 1);
+        assert_eq!(stats.active_jobs, 0);
+        assert_eq!(stats.total_volume, 1_000_000);
+    }
+
+    #[test]
+    fn dashboard_stats_counts_active_and_completed() {
+        let (env, client, admin, user, freelancer, native_token) = setup();
+        let asset = token::StellarAssetClient::new(&env, &native_token);
+        asset.mint(&user, &10_000_000_000i128);
+
+        // Post and complete one job
+        let j1 = client.post_job(&user, &1_000_000i128, &hash(&env), &32u32, &0u64, &native_token);
+        client.accept_job(&freelancer, &j1);
+        client.submit_work(&freelancer, &j1);
+        client.approve_work(&user, &j1);
+
+        // Post and accept (InProgress) another
+        let h2 = BytesN::from_array(&env, &[8; 32]);
+        let j2 = client.post_job(&user, &500_000i128, &h2, &32u32, &0u64, &native_token);
+        client.accept_job(&freelancer, &j2);
+
+        let stats = client.get_dashboard_stats(&admin);
+        assert_eq!(stats.total_jobs, 2);
+        assert_eq!(stats.open_jobs, 0);
+        assert_eq!(stats.active_jobs, 1);
+        assert_eq!(stats.completed_jobs, 1);
+        assert_eq!(stats.cancelled_jobs, 0);
+        assert_eq!(stats.total_volume, 1_500_000);
+        // fees accrued from j1 approval
+        let expected_fee = 1_000_000 * DEFAULT_FEE_BPS / BPS_DENOMINATOR;
+        assert_eq!(stats.total_fees_accrued, expected_fee);
+    }
+
+    #[test]
+    fn dashboard_stats_counts_cancelled_and_disputed() {
+        let (env, client, admin, user, freelancer, native_token) = setup();
+
+        // Post and cancel one job
+        let j1 = client.post_job(&user, &1_000_000i128, &hash(&env), &32u32, &0u64, &native_token);
+        client.cancel_job(&user, &j1);
+
+        // Post and dispute another
+        let h2 = BytesN::from_array(&env, &[8; 32]);
+        let j2 = client.post_job(&user, &1_000_000i128, &h2, &32u32, &0u64, &native_token);
+        client.accept_job(&freelancer, &j2);
+        client.raise_dispute(&user, &j2);
+
+        let stats = client.get_dashboard_stats(&admin);
+        assert_eq!(stats.cancelled_jobs, 1);
+        assert_eq!(stats.disputed_jobs, 1);
+        assert_eq!(stats.total_volume, 2_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #13)")]
+    fn dashboard_stats_rejects_non_admin() {
+        let (_, client, _, user, _, _) = setup();
+        client.get_dashboard_stats(&user);
     }
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,97 @@
+# StellarWork Contract API Reference
+
+The [`openapi.yaml`](./openapi.yaml) file in this directory is an **OpenAPI 3.0**
+specification that documents every public function of the StellarWork escrow
+smart contract as a REST-like endpoint.
+
+## How to use this spec
+
+### Browse interactively
+
+Paste the raw URL of `openapi.yaml` (or a local file path) into
+[Swagger Editor](https://editor.swagger.io/) or
+[Redoc](https://redocly.github.io/redoc/) to render interactive documentation.
+
+### Generate a TypeScript client
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i docs/api/openapi.yaml \
+  -g typescript-fetch \
+  -o generated/stellar-work-client
+```
+
+### Validate the spec
+
+```bash
+npx @redocly/cli lint docs/api/openapi.yaml
+```
+
+## Example calls (curl)
+
+> All Soroban contract invocations are submitted as XDR-encoded transactions via
+> the Soroban RPC `sendTransaction` method.  The examples below use the
+> [soroban-cli](https://github.com/stellar/soroban-tools) for convenience.
+
+### Get a job by ID
+
+```bash
+soroban contract invoke \
+  --network testnet \
+  --id <CONTRACT_ID> \
+  -- get_job \
+  --job_id 1
+```
+
+### Post a job
+
+```bash
+soroban contract invoke \
+  --network testnet \
+  --source <CLIENT_SECRET> \
+  --id <CONTRACT_ID> \
+  -- post_job \
+  --client <CLIENT_ADDRESS> \
+  --amount 10000000 \
+  --desc_hash <32_BYTE_HEX> \
+  --description_payload_len 512 \
+  --deadline 0 \
+  --token <TOKEN_ADDRESS>
+```
+
+### Get dashboard stats (admin)
+
+```bash
+soroban contract invoke \
+  --network testnet \
+  --source <ADMIN_SECRET> \
+  --id <CONTRACT_ID> \
+  -- get_dashboard_stats \
+  --admin <ADMIN_ADDRESS>
+```
+
+## Authentication
+
+StellarWork uses **wallet signatures** for authentication — there are no API
+keys or bearer tokens.  Every mutating call must be submitted as a signed
+Stellar transaction.
+
+1. Build a Soroban `InvokeHostFunction` operation containing the contract call.
+2. Sign the transaction envelope with the caller's private key.
+3. Submit via `sendTransaction` to the Soroban RPC.
+
+The contract validates `require_auth()` for each privileged caller inside the
+WASM execution — the RPC node enforces the cryptographic signature.
+
+## Servers
+
+| Environment | RPC URL |
+|-------------|---------|
+| Testnet | `https://soroban-testnet.stellar.org` |
+| Futurenet | `https://rpc-futurenet.stellar.org` |
+| Mainnet | `https://mainnet.stellar.gateway.fm` |
+
+## Contract addresses
+
+Deployed contract addresses are tracked in
+[`docs/environments.md`](../environments.md).

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,988 @@
+openapi: "3.0.3"
+
+info:
+  title: StellarWork Escrow Contract API
+  version: "1.0.0"
+  description: |
+    Machine-readable specification for all StellarWork escrow smart-contract
+    functions, expressed as REST-like endpoints for use with code generators,
+    SDK scaffolding, and developer tooling.
+
+    All calls are submitted as Soroban contract invocations against the
+    deployed contract address.  Authentication is performed via wallet
+    signature (see **Authentication** below).
+  contact:
+    name: StellarWork
+    url: https://github.com/anoncon/Stellar-work-
+
+servers:
+  - url: https://soroban-testnet.stellar.org
+    description: Testnet RPC
+  - url: https://rpc-futurenet.stellar.org
+    description: Futurenet RPC
+  - url: https://mainnet.stellar.gateway.fm
+    description: Mainnet RPC
+
+tags:
+  - name: Jobs
+    description: Job lifecycle — post, accept, submit, approve, reject, cancel
+  - name: Disputes
+    description: Dispute creation and resolution
+  - name: Fees
+    description: Platform fee queries and admin withdrawal
+  - name: Admin
+    description: Admin-only job views and platform management
+  - name: Stats
+    description: Platform statistics dashboard
+  - name: Access
+    description: Blacklist / whitelist access control
+  - name: Referrals
+    description: Referral codes and earnings
+  - name: Tokens
+    description: Allowed-token management
+  - name: Upgrade
+    description: Contract upgrade timelock workflow
+  - name: Ownership
+    description: Two-step admin ownership transfer
+
+paths:
+  /contract/post_job:
+    post:
+      operationId: postJob
+      tags: [Jobs]
+      summary: Post a new job
+      description: |
+        Escrows `amount` tokens from the client's wallet and creates a new job
+        in `Open` status.  Requires client wallet signature.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostJobRequest"
+      responses:
+        "200":
+          description: Job ID assigned to the new job
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: uint64
+                example: 42
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/post_job_with_referral:
+    post:
+      operationId: postJobWithReferral
+      tags: [Jobs, Referrals]
+      summary: Post a job and attribute to a referrer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/PostJobRequest"
+                - type: object
+                  required: [referral_code]
+                  properties:
+                    referral_code:
+                      type: string
+                      description: Referral code registered by the referrer
+      responses:
+        "200":
+          description: Job ID
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: uint64
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/accept_job:
+    post:
+      operationId: acceptJob
+      tags: [Jobs]
+      summary: Freelancer accepts an open job
+      description: Transitions the job from `Open` to `InProgress`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [freelancer, job_id]
+              properties:
+                freelancer:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Job accepted successfully
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/submit_work:
+    post:
+      operationId: submitWork
+      tags: [Jobs]
+      summary: Freelancer submits completed work for review
+      description: Transitions the job from `InProgress` to `SubmittedForReview`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [freelancer, job_id]
+              properties:
+                freelancer:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Work submitted
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/approve_work:
+    post:
+      operationId: approveWork
+      tags: [Jobs]
+      summary: Client approves submitted work and releases payment
+      description: |
+        Transitions the job to `Completed`, deducts the platform fee, and
+        transfers the net payout to the freelancer.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client, job_id]
+              properties:
+                client:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Work approved and payment released
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/reject_work:
+    post:
+      operationId: rejectWork
+      tags: [Jobs]
+      summary: Client rejects submitted work (revision cycle)
+      description: |
+        Returns the job to `InProgress` and increments the revision counter.
+        Panics once `MAX_REVISIONS` (3) is reached.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client, job_id]
+              properties:
+                client:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Work rejected, revision requested
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/cancel_job:
+    post:
+      operationId: cancelJob
+      tags: [Jobs]
+      summary: Client cancels an open job and receives a full refund
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client, job_id]
+              properties:
+                client:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Job cancelled and escrowed amount refunded
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/freelancer_cancel_job:
+    post:
+      operationId: freelancerCancelJob
+      tags: [Jobs]
+      summary: Freelancer cancels an in-progress job (refunds client)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [freelancer, job_id]
+              properties:
+                freelancer:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Job cancelled and escrowed amount refunded to client
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/enforce_deadline:
+    post:
+      operationId: enforceDeadline
+      tags: [Jobs]
+      summary: Client enforces an expired deadline and reclaims funds
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client, job_id]
+              properties:
+                client:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Deadline enforced and funds returned to client
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/mutual_cancel:
+    post:
+      operationId: mutualCancel
+      tags: [Jobs]
+      summary: Both parties agree to cancel and split the escrowed amount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client, freelancer, job_id, client_share_bps]
+              properties:
+                client:
+                  $ref: "#/components/schemas/Address"
+                freelancer:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+                client_share_bps:
+                  type: integer
+                  description: Basis-points (0–10 000) awarded to the client
+      responses:
+        "200":
+          description: Job cancelled with agreed split
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/get_job:
+    get:
+      operationId: getJob
+      tags: [Jobs]
+      summary: Retrieve a single job by ID
+      parameters:
+        - name: job_id
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: uint64
+      responses:
+        "200":
+          description: Job data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Job"
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/get_job_count:
+    get:
+      operationId: getJobCount
+      tags: [Jobs]
+      summary: Total number of jobs posted (ever)
+      responses:
+        "200":
+          description: Total job count
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: uint64
+
+  /contract/get_jobs_batch:
+    get:
+      operationId: getJobsBatch
+      tags: [Jobs]
+      summary: Retrieve a paginated slice of jobs
+      parameters:
+        - name: start_id
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: uint64
+        - name: limit
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: uint32
+      responses:
+        "200":
+          description: Array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Job"
+
+  /contract/raise_dispute:
+    post:
+      operationId: raiseDispute
+      tags: [Disputes]
+      summary: Raise a dispute on an in-progress or submitted job
+      description: |
+        Requires the caller to deposit the dispute fee (native token).
+        Transitions the job to `Disputed`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [caller, job_id]
+              properties:
+                caller:
+                  $ref: "#/components/schemas/Address"
+                job_id:
+                  type: integer
+                  format: uint64
+      responses:
+        "200":
+          description: Dispute raised
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/resolve_dispute:
+    post:
+      operationId: resolveDispute
+      tags: [Disputes, Admin]
+      summary: Admin resolves a disputed job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [job_id, resolution]
+              properties:
+                job_id:
+                  type: integer
+                  format: uint64
+                resolution:
+                  $ref: "#/components/schemas/DisputeResolution"
+      responses:
+        "200":
+          description: Dispute resolved and funds distributed
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/batch_resolve_disputes:
+    post:
+      operationId: batchResolveDisputes
+      tags: [Disputes, Admin]
+      summary: Resolve up to 20 disputed jobs in a single call
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, job_ids, resolutions]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                job_ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: uint64
+                  maxItems: 20
+                resolutions:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/DisputeResolution"
+                  maxItems: 20
+      responses:
+        "200":
+          description: All disputes resolved
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/get_fees:
+    get:
+      operationId: getFees
+      tags: [Fees]
+      summary: Accumulated platform fees for a given token
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Fee amount in stroops
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int128
+
+  /contract/withdraw_fees:
+    post:
+      operationId: withdrawFees
+      tags: [Fees, Admin]
+      summary: Admin withdraws all accrued fees for a token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Fees transferred to admin wallet
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/get_fee_bps:
+    get:
+      operationId: getFeeBps
+      tags: [Fees]
+      summary: Current platform fee in basis points
+      responses:
+        "200":
+          description: Fee in basis points (e.g. 250 = 2.5%)
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int128
+
+  /contract/get_dashboard_stats:
+    post:
+      operationId: getDashboardStats
+      tags: [Stats, Admin]
+      summary: All platform metrics in a single call (SC-81)
+      description: |
+        Returns aggregated job-status counters, total volume, and accrued fees
+        in one contract invocation — avoiding multiple round-trips for dashboards.
+        Requires admin authentication.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Platform dashboard statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DashboardStats"
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/admin_get_all_jobs:
+    post:
+      operationId: adminGetAllJobs
+      tags: [Admin]
+      summary: Paginated list of all jobs (admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, start_index, limit]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                start_index:
+                  type: integer
+                  format: uint32
+                limit:
+                  type: integer
+                  format: uint32
+      responses:
+        "200":
+          description: Array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Job"
+
+  /contract/admin_get_jobs_by_status:
+    post:
+      operationId: adminGetJobsByStatus
+      tags: [Admin]
+      summary: Filtered paginated job list by status (admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, status, start_index, limit]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                status:
+                  $ref: "#/components/schemas/JobStatus"
+                start_index:
+                  type: integer
+                  format: uint32
+                limit:
+                  type: integer
+                  format: uint32
+      responses:
+        "200":
+          description: Filtered array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Job"
+
+  /contract/add_to_blacklist:
+    post:
+      operationId: addToBlacklist
+      tags: [Access, Admin]
+      summary: Admin blacklists an address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, address]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                address:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Address blacklisted
+        "400":
+          $ref: "#/components/responses/ContractError"
+
+  /contract/add_to_whitelist:
+    post:
+      operationId: addToWhitelist
+      tags: [Access, Admin]
+      summary: Admin whitelists an address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, address]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                address:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Address whitelisted
+
+  /contract/set_whitelist_mode:
+    post:
+      operationId: setWhitelistMode
+      tags: [Access, Admin]
+      summary: Enable or disable whitelist-only mode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, enabled]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                enabled:
+                  type: boolean
+      responses:
+        "200":
+          description: Whitelist mode updated
+
+  /contract/register_referral:
+    post:
+      operationId: registerReferral
+      tags: [Referrals]
+      summary: Register a referral code tied to the caller
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [referrer, code]
+              properties:
+                referrer:
+                  $ref: "#/components/schemas/Address"
+                code:
+                  type: string
+      responses:
+        "200":
+          description: Referral code registered
+
+  /contract/get_referral_earnings:
+    get:
+      operationId: getReferralEarnings
+      tags: [Referrals]
+      summary: Accumulated referral earnings for an address
+      parameters:
+        - name: referrer
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Earnings in stroops
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int128
+
+  /contract/add_allowed_token:
+    post:
+      operationId: addAllowedToken
+      tags: [Tokens, Admin]
+      summary: Admin adds a token to the allowed-token list
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Token allowed
+
+  /contract/propose_upgrade:
+    post:
+      operationId: proposeUpgrade
+      tags: [Upgrade, Admin]
+      summary: Admin proposes a contract upgrade (starts 24 h timelock)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, new_wasm_hash]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                new_wasm_hash:
+                  type: string
+                  description: Hex-encoded 32-byte WASM hash
+      responses:
+        "200":
+          description: Upgrade proposed
+
+  /contract/execute_upgrade:
+    post:
+      operationId: executeUpgrade
+      tags: [Upgrade, Admin]
+      summary: Execute a previously proposed upgrade after timelock expiry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Contract upgraded
+
+  /contract/transfer_ownership:
+    post:
+      operationId: transferOwnership
+      tags: [Ownership, Admin]
+      summary: Nominate a new admin (step 1 of 2)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [admin, new_admin]
+              properties:
+                admin:
+                  $ref: "#/components/schemas/Address"
+                new_admin:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Transfer initiated
+
+  /contract/accept_ownership:
+    post:
+      operationId: acceptOwnership
+      tags: [Ownership]
+      summary: Nominee accepts admin role (step 2 of 2)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [new_admin]
+              properties:
+                new_admin:
+                  $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Ownership transferred
+
+components:
+  schemas:
+    Address:
+      type: string
+      description: Stellar account or contract address (G… or C… public key)
+      example: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN
+
+    JobStatus:
+      type: string
+      enum:
+        - Open
+        - InProgress
+        - SubmittedForReview
+        - Completed
+        - Cancelled
+        - Disputed
+      description: Current lifecycle state of a job
+
+    Job:
+      type: object
+      properties:
+        client:
+          $ref: "#/components/schemas/Address"
+        freelancer:
+          oneOf:
+            - $ref: "#/components/schemas/Address"
+            - type: "null"
+        amount:
+          type: integer
+          format: int128
+          description: Escrowed amount in stroops
+        description_hash:
+          type: string
+          description: 32-byte SHA-256 hash of the job description (hex)
+        status:
+          $ref: "#/components/schemas/JobStatus"
+        created_at:
+          type: integer
+          format: uint64
+          description: Unix timestamp of job creation
+        deadline:
+          type: integer
+          format: uint64
+          description: Unix timestamp deadline (0 means no deadline)
+        token:
+          $ref: "#/components/schemas/Address"
+        revision_count:
+          type: integer
+          format: uint32
+
+    DisputeResolution:
+      type: object
+      required: [client_bps]
+      properties:
+        client_bps:
+          type: integer
+          format: uint32
+          minimum: 0
+          maximum: 10000
+          description: |
+            Basis-points share awarded to the client (0–10 000).
+            Remainder goes to the freelancer after the platform fee.
+
+    DashboardStats:
+      type: object
+      description: All platform metrics returned in a single call (SC-81)
+      properties:
+        total_jobs:
+          type: integer
+          format: uint64
+        open_jobs:
+          type: integer
+          format: uint64
+        active_jobs:
+          type: integer
+          format: uint64
+          description: InProgress + SubmittedForReview
+        completed_jobs:
+          type: integer
+          format: uint64
+        cancelled_jobs:
+          type: integer
+          format: uint64
+        disputed_jobs:
+          type: integer
+          format: uint64
+        total_fees_accrued:
+          type: integer
+          format: int128
+          description: Native-token fees accrued (stroops)
+        total_volume:
+          type: integer
+          format: int128
+          description: Sum of all job amounts ever posted (stroops)
+
+    PostJobRequest:
+      type: object
+      required: [client, amount, desc_hash, description_payload_len, deadline, token]
+      properties:
+        client:
+          $ref: "#/components/schemas/Address"
+        amount:
+          type: integer
+          format: int128
+          description: Amount to escrow in stroops (must be > 0)
+        desc_hash:
+          type: string
+          description: 32-byte SHA-256 hash of the job description (hex)
+        description_payload_len:
+          type: integer
+          format: uint32
+          description: Byte length of the description payload stored off-chain
+        deadline:
+          type: integer
+          format: uint64
+          description: Unix timestamp deadline (0 = no deadline)
+        token:
+          $ref: "#/components/schemas/Address"
+
+    ErrorCode:
+      type: integer
+      format: uint32
+      description: |
+        Contract error codes returned on failure:
+        - 1  JobNotFound
+        - 2  Unauthorized
+        - 3  InvalidStatus
+        - 4  InsufficientFunds
+        - 5  JobAlreadyAccepted
+        - 6  DeadlinePassed
+        - 7  DeadlineNotExpired
+        - 8  TokenNotAllowed
+        - 9  FeeTooHigh
+        - 10 AlreadyInitialized
+        - 11 InvalidAmount
+        - 12 InvalidDescriptionHash
+        - 13 UnauthorizedAdmin
+        - 14 InvalidDeadline
+        - 15 ActiveJobLimitExceeded
+        - 16 RevisionLimitReached
+        - 17 DescriptionPayloadTooLarge
+        - 18 UpgradeNotApproved
+        - 19 UpgradeTimelockPending
+        - 20 NoPendingUpgrade
+        - 21 ReferralCodeAlreadyExists
+        - 22 ReferralCodeNotFound
+        - 23 InsufficientReferralEarnings
+        - 24 BlacklistedUser
+        - 25 NotWhitelisted
+        - 26 SelfReferralNotAllowed
+        - 31 BatchSizeMismatch
+        - 32 BatchTooLarge
+
+  responses:
+    ContractError:
+      description: Contract-level error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Human-readable error description
+              code:
+                $ref: "#/components/schemas/ErrorCode"
+
+  securitySchemes:
+    WalletSignature:
+      type: apiKey
+      in: header
+      name: X-Wallet-Signature
+      description: |
+        All mutating contract calls must include a valid Stellar transaction
+        envelope signed by the relevant party's private key.  The Soroban RPC
+        validates the signature; no bearer token is exchanged with a server.
+
+security:
+  - WalletSignature: []

--- a/frontend/__tests__/app-footer-version.test.tsx
+++ b/frontend/__tests__/app-footer-version.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+import AppFooter from "@/components/AppFooter";
+
+describe("AppFooter version display", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.2.3");
+    vi.stubEnv("NEXT_PUBLIC_DEPLOY_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_COMMIT_SHA", "abc1234def5678");
+    vi.stubEnv("NEXT_PUBLIC_BUILD_TIME", "2026-06-29T12:00:00Z");
+  });
+
+  it("renders version string in footer", () => {
+    render(<AppFooter />);
+    expect(screen.getByText(/StellarWork/)).toBeInTheDocument();
+  });
+
+  it("renders footer navigation links", () => {
+    render(<AppFooter />);
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Documentation" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "License" })).toBeInTheDocument();
+  });
+
+  it("version badge button has accessible label", () => {
+    render(<AppFooter />);
+    const btn = screen.getByRole("button", { name: /App version/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("shows build tooltip on focus", () => {
+    render(<AppFooter />);
+    const btn = screen.getByRole("button", { name: /App version/i });
+    fireEvent.focus(btn);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("hides tooltip after blur", () => {
+    render(<AppFooter />);
+    const btn = screen.getByRole("button", { name: /App version/i });
+    fireEvent.focus(btn);
+    fireEvent.blur(btn);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders copyright notice", () => {
+    render(<AppFooter />);
+    expect(screen.getByText(/StellarWork\. All rights reserved\./)).toBeInTheDocument();
+  });
+
+  it("footer element has correct landmark role", () => {
+    render(<AppFooter />);
+    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/voice-nav.test.tsx
+++ b/frontend/__tests__/voice-nav.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, back: mockBack }),
+}));
+
+import VoiceNav from "@/components/VoiceNav";
+
+function makeMockRecognition() {
+  return {
+    continuous: false,
+    interimResults: false,
+    lang: "",
+    start: vi.fn(),
+    stop: vi.fn(),
+    onresult: null as ((e: unknown) => void) | null,
+    onerror: null as ((e: unknown) => void) | null,
+    onend: null as (() => void) | null,
+  };
+}
+
+describe("VoiceNav", () => {
+  let mockRecognition: ReturnType<typeof makeMockRecognition>;
+
+  beforeEach(() => {
+    mockRecognition = makeMockRecognition();
+    const Ctor = vi.fn(() => mockRecognition);
+    Object.defineProperty(window, "SpeechRecognition", {
+      value: Ctor,
+      writable: true,
+      configurable: true,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).SpeechRecognition;
+  });
+
+  it("renders microphone button when speech recognition is supported", () => {
+    render(<VoiceNav />);
+    expect(
+      screen.getByRole("button", { name: /start voice navigation/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when speech recognition is unavailable", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).SpeechRecognition;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).webkitSpeechRecognition;
+    const { container } = render(<VoiceNav />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("starts recognition and shows stop button on click", () => {
+    render(<VoiceNav />);
+    fireEvent.click(screen.getByRole("button", { name: /start voice navigation/i }));
+    expect(mockRecognition.start).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("button", { name: /stop voice navigation/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates home on 'go home' command", () => {
+    render(<VoiceNav />);
+    fireEvent.click(screen.getByRole("button", { name: /start voice navigation/i }));
+
+    mockRecognition.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        item: () => ({ isFinal: true, 0: { transcript: "go home" } }),
+        0: { isFinal: true, 0: { transcript: "go home" } },
+      },
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+
+  it("navigates to dashboard on 'go to dashboard' command", () => {
+    render(<VoiceNav />);
+    fireEvent.click(screen.getByRole("button", { name: /start voice navigation/i }));
+
+    mockRecognition.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        item: () => ({ isFinal: true, 0: { transcript: "go to dashboard" } }),
+        0: { isFinal: true, 0: { transcript: "go to dashboard" } },
+      },
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("shows status feedback after recognized command", () => {
+    render(<VoiceNav />);
+    fireEvent.click(screen.getByRole("button", { name: /start voice navigation/i }));
+
+    mockRecognition.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        item: () => ({ isFinal: true, 0: { transcript: "post job" } }),
+        0: { isFinal: true, 0: { transcript: "post job" } },
+      },
+    });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows error message on microphone denial", () => {
+    render(<VoiceNav />);
+    fireEvent.click(screen.getByRole("button", { name: /start voice navigation/i }));
+
+    mockRecognition.onerror?.({ error: "not-allowed" });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Microphone access denied");
+  });
+
+  it("button has aria-pressed=true while listening", () => {
+    render(<VoiceNav />);
+    const btn = screen.getByRole("button", { name: /start voice navigation/i });
+    fireEvent.click(btn);
+    expect(
+      screen.getByRole("button", { name: /stop voice navigation/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,7 +14,7 @@ import CommandPalette from "@/components/CommandPalette";
 import OnboardingProvider from "@/components/OnboardingProvider";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
 import JsonLd from "@/components/JsonLd";
-import Link from "next/link";
+import AppFooter from "@/components/AppFooter";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -145,30 +145,7 @@ export default async function RootLayout({
           <main id="main-content" tabIndex={-1} className="mx-auto w-full max-w-5xl flex-1 px-3 py-6 sm:px-4 sm:py-8">
             <ErrorBoundary>{children}</ErrorBoundary>
           </main>
-          <footer className="mt-auto border-t border-slate-200 bg-white py-8 pb-[calc(2rem+env(safe-area-inset-bottom))] dark:border-slate-800 dark:bg-slate-900">
-            <div className="mx-auto max-w-5xl px-4">
-              <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
-                <div className="flex flex-col items-center gap-2 md:items-start">
-                  <span className="text-lg font-bold text-slate-900 dark:text-slate-100">StellarWork</span>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Decentralized Escrow Marketplace</p>
-                </div>
-
-                <nav className="flex flex-wrap justify-center gap-8 text-sm font-medium text-slate-600 dark:text-slate-400">
-                  <a href="https://github.com/anumukul/Stellar-work-" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">GitHub</a>
-                  <Link href="/docs" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Documentation</Link>
-                  <a href="/LICENSE" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">License</a>
-                </nav>
-
-                <div className="flex items-center gap-2 rounded-full bg-slate-50 px-4 py-2 border border-slate-100 dark:bg-slate-800 dark:border-slate-700">
-                  <span className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Built on</span>
-                  <span className="text-sm font-bold text-slate-800 dark:text-slate-200">Stellar</span>
-                </div>
-              </div>
-              <div className="mt-8 border-t border-slate-100 pt-8 text-center text-xs text-slate-400 dark:border-slate-800 dark:text-slate-500">
-                &copy; {new Date().getFullYear()} StellarWork. All rights reserved.
-              </div>
-            </div>
-          </footer>
+          <AppFooter />
           </ToastProvider>
           </MessagingProvider>
           </NotificationProvider>

--- a/frontend/app/navigation.tsx
+++ b/frontend/app/navigation.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useRef } from "react";
 import NetworkBadge from "@/components/NetworkBadge";
 import NotificationInbox from "@/components/NotificationInbox";
 import WalletMenu from "@/components/WalletMenu";
+import VoiceNav from "@/components/VoiceNav";
 
 function ThemeToggle() {
   const { theme, setTheme } = useTheme();
@@ -209,6 +210,7 @@ export function Navigation() {
             ))}
           </nav>
 
+          <VoiceNav />
           <NotificationInbox />
           <ThemeToggle />
           <LanguageSwitcher />

--- a/frontend/components/AppFooter.tsx
+++ b/frontend/components/AppFooter.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
+const BUILD_TIME = process.env.NEXT_PUBLIC_BUILD_TIME ?? "";
+const COMMIT_SHA = process.env.NEXT_PUBLIC_COMMIT_SHA ?? "";
+const DEPLOY_ENV = process.env.NEXT_PUBLIC_DEPLOY_ENV ?? "development";
+
+const ENV_BADGE: Record<string, { label: string; className: string }> = {
+  production: {
+    label: "production",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  staging: {
+    label: "staging",
+    className:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  },
+  preview: {
+    label: "preview",
+    className:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  },
+  development: {
+    label: "dev",
+    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  },
+};
+
+function VersionBadge() {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const badge = ENV_BADGE[DEPLOY_ENV] ?? ENV_BADGE.development;
+  const shortSha = COMMIT_SHA ? COMMIT_SHA.slice(0, 7) : null;
+  const buildDate = BUILD_TIME
+    ? new Date(BUILD_TIME).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })
+    : null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative">
+        <button
+          type="button"
+          aria-label={`App version ${APP_VERSION}, environment ${badge.label}${shortSha ? `, commit ${shortSha}` : ""}`}
+          aria-describedby="version-tooltip"
+          className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 transition-colors hover:border-slate-300 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700"
+          onMouseEnter={() => setTooltipVisible(true)}
+          onMouseLeave={() => setTooltipVisible(false)}
+          onFocus={() => setTooltipVisible(true)}
+          onBlur={() => setTooltipVisible(false)}
+        >
+          <span>StellarWork v{APP_VERSION}</span>
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${badge.className}`}
+            aria-hidden="true"
+          >
+            {badge.label}
+          </span>
+        </button>
+
+        {tooltipVisible && (shortSha || buildDate) && (
+          <div
+            id="version-tooltip"
+            role="tooltip"
+            className="absolute bottom-full left-1/2 z-50 mb-2 w-56 -translate-x-1/2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs shadow-lg dark:border-slate-700 dark:bg-slate-800"
+          >
+            <dl className="space-y-1">
+              {buildDate && (
+                <div className="flex justify-between gap-3">
+                  <dt className="text-slate-500 dark:text-slate-400">
+                    Build time
+                  </dt>
+                  <dd className="font-medium text-slate-700 dark:text-slate-300">
+                    {buildDate}
+                  </dd>
+                </div>
+              )}
+              {shortSha && (
+                <div className="flex justify-between gap-3">
+                  <dt className="text-slate-500 dark:text-slate-400">Commit</dt>
+                  <dd className="font-mono font-medium text-slate-700 dark:text-slate-300">
+                    {shortSha}
+                  </dd>
+                </div>
+              )}
+              <div className="flex justify-between gap-3">
+                <dt className="text-slate-500 dark:text-slate-400">
+                  Environment
+                </dt>
+                <dd className="font-medium text-slate-700 dark:text-slate-300">
+                  {DEPLOY_ENV}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AppFooter() {
+  return (
+    <footer className="mt-auto border-t border-slate-200 bg-white py-8 pb-[calc(2rem+env(safe-area-inset-bottom))] dark:border-slate-800 dark:bg-slate-900">
+      <div className="mx-auto max-w-5xl px-4">
+        <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+          <div className="flex flex-col items-center gap-2 md:items-start">
+            <span className="text-lg font-bold text-slate-900 dark:text-slate-100">
+              StellarWork
+            </span>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Decentralized Escrow Marketplace
+            </p>
+          </div>
+
+          <nav
+            aria-label="Footer navigation"
+            className="flex flex-wrap justify-center gap-8 text-sm font-medium text-slate-600 dark:text-slate-400"
+          >
+            <a
+              href="https://github.com/anoncon/Stellar-work-"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+            >
+              GitHub
+            </a>
+            <Link
+              href="/docs"
+              className="transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+            >
+              Documentation
+            </Link>
+            <a
+              href="/LICENSE"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+            >
+              License
+            </a>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border border-slate-100 bg-slate-50 px-4 py-2 dark:border-slate-700 dark:bg-slate-800">
+              <span className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                Built on
+              </span>
+              <span className="text-sm font-bold text-slate-800 dark:text-slate-200">
+                Stellar
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col items-center justify-between gap-3 border-t border-slate-100 pt-6 sm:flex-row dark:border-slate-800">
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            &copy; {new Date().getFullYear()} StellarWork. All rights reserved.
+          </p>
+          <VersionBadge />
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/components/VoiceNav.tsx
+++ b/frontend/components/VoiceNav.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+
+const COMMANDS: Record<string, () => void | string> = {};
+
+type CommandHandler = (router: ReturnType<typeof useRouter>) => void;
+
+const NAVIGATION_COMMANDS: Record<string, CommandHandler> = {
+  "go home": (r) => r.push("/"),
+  "go to home": (r) => r.push("/"),
+  "go to dashboard": (r) => r.push("/dashboard"),
+  "open dashboard": (r) => r.push("/dashboard"),
+  "go to admin": (r) => r.push("/admin"),
+  "open admin": (r) => r.push("/admin"),
+  "go to settings": (r) => r.push("/settings"),
+  "open settings": (r) => r.push("/settings"),
+  "post a job": (r) => r.push("/post-job"),
+  "post job": (r) => r.push("/post-job"),
+  "new job": (r) => r.push("/post-job"),
+  "go to transactions": (r) => r.push("/transactions"),
+  "open transactions": (r) => r.push("/transactions"),
+  "go to disputes": (r) => r.push("/disputes"),
+  "open disputes": (r) => r.push("/disputes"),
+  "go to messages": (r) => r.push("/messages"),
+  "open messages": (r) => r.push("/messages"),
+  "go back": (r) => r.back(),
+  "scroll down": () => window.scrollBy({ top: 400, behavior: "smooth" }),
+  "scroll up": () => window.scrollBy({ top: -400, behavior: "smooth" }),
+};
+
+function matchCommand(transcript: string): CommandHandler | null {
+  const normalized = transcript.toLowerCase().trim();
+  for (const [phrase, handler] of Object.entries(NAVIGATION_COMMANDS)) {
+    if (normalized.includes(phrase)) return handler;
+  }
+  return null;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionEvent {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+}
+
+interface SpeechRecognitionErrorEvent {
+  error: string;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: new () => SpeechRecognition;
+    webkitSpeechRecognition?: new () => SpeechRecognition;
+  }
+}
+
+function getSpeechRecognition(): (new () => SpeechRecognition) | null {
+  if (typeof window === "undefined") return null;
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+}
+
+export default function VoiceNav() {
+  const router = useRouter();
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [lastCommand, setLastCommand] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const statusTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setSupported(getSpeechRecognition() !== null);
+  }, []);
+
+  const clearStatus = useCallback(() => {
+    if (statusTimeout.current) clearTimeout(statusTimeout.current);
+    statusTimeout.current = setTimeout(() => {
+      setLastCommand(null);
+      setError(null);
+    }, 3000);
+  }, []);
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop();
+    setListening(false);
+  }, []);
+
+  const startListening = useCallback(() => {
+    const SpeechRecognitionAPI = getSpeechRecognition();
+    if (!SpeechRecognitionAPI) return;
+
+    const recognition = new SpeechRecognitionAPI();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.lang = "en-US";
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript =
+        event.results[event.resultIndex][0].transcript;
+      const handler = matchCommand(transcript);
+      if (handler) {
+        setLastCommand(transcript);
+        handler(router);
+      } else {
+        setLastCommand(`Unknown: "${transcript}"`);
+      }
+      clearStatus();
+      setListening(false);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error !== "no-speech") {
+        setError(event.error === "not-allowed" ? "Microphone access denied" : event.error);
+        clearStatus();
+      }
+      setListening(false);
+    };
+
+    recognition.onend = () => {
+      setListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    setListening(true);
+    setError(null);
+    setLastCommand(null);
+  }, [router, clearStatus]);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+      if (statusTimeout.current) clearTimeout(statusTimeout.current);
+    };
+  }, []);
+
+  if (!supported) return null;
+
+  return (
+    <div className="relative flex items-center">
+      <button
+        onClick={listening ? stopListening : startListening}
+        aria-label={listening ? "Stop voice navigation" : "Start voice navigation"}
+        aria-pressed={listening}
+        title={listening ? "Listening… click to stop" : "Voice navigation"}
+        className={`rounded-md p-2 transition-colors ${
+          listening
+            ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+            : "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+        }`}
+      >
+        {listening ? (
+          <svg
+            className="h-5 w-5 animate-pulse"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M12 1a4 4 0 0 1 4 4v6a4 4 0 0 1-8 0V5a4 4 0 0 1 4-4zm-1 16.93V20H9v2h6v-2h-2v-2.07A8.001 8.001 0 0 0 20 11h-2a6 6 0 0 1-12 0H4a8.001 8.001 0 0 0 7 7.93z" />
+          </svg>
+        ) : (
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 0 1 6 0v8.25a3 3 0 0 1-3 3z"
+            />
+          </svg>
+        )}
+      </button>
+
+      {(lastCommand || error) && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="absolute left-1/2 top-full z-50 mt-2 w-48 -translate-x-1/2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-800"
+        >
+          {error ? (
+            <span className="text-red-600 dark:text-red-400">{error}</span>
+          ) : (
+            <span className="text-slate-700 dark:text-slate-300">
+              <span className="font-medium">Heard:</span> {lastCommand}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,6 +3,13 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version ?? "0.1.0",
+    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+    NEXT_PUBLIC_COMMIT_SHA: process.env.COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? "",
+    NEXT_PUBLIC_DEPLOY_ENV: process.env.DEPLOY_ENV ?? process.env.VERCEL_ENV ?? "development",
+  },
+};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary

- **SC-81** — `get_dashboard_stats(admin)` returns all key platform metrics in a single RPC call, eliminating N+1 round-trips for dashboards. Includes 5 unit tests verifying counter accuracy.
- **FE-109** — Voice navigation via Web Speech API. Microphone button in nav bar; supports 20+ commands ("go home", "go to dashboard", "post job", "scroll down", etc.). Degrades gracefully when API is unavailable. Unit tests cover command routing, error handling, and ARIA attributes.
- **DOC-30** — `docs/api/openapi.yaml` — OpenAPI 3.0 spec documenting all smart-contract public functions (schemas, error codes, servers for testnet/futurenet/mainnet). `docs/api/README.md` covers code-gen, curl examples, and authentication.
- **FE-110** — `AppFooter` reads version, build time, commit SHA, and deploy env at build time via `next.config.ts`. Displays version string with colour-coded env badge and hover/focus tooltip. Fully accessible (screen-reader label, `role="tooltip"`, `role="status"`).

## Test plan

- [ ] `cargo test -p escrow` — all contract tests pass including 5 new `dashboard_stats_*` tests
- [ ] `npm test` inside `frontend/` — all vitest tests pass including `app-footer-version` and `voice-nav` suites
- [ ] Click the microphone icon in nav — try "go to dashboard", "go home"
- [ ] Hover / focus the version badge in footer — tooltip shows build info
- [ ] Verify footer in dark mode — badge and tooltip colours correct
- [ ] Validate spec: `npx @redocly/cli lint docs/api/openapi.yaml`

Closes #505
Closes #506
Closes #507
Closes #508
