### PR TITLE
Add admin emergency cancellation for stuck jobs

### DIFF
--- a/docs/issue-496-emergency-cancel-scaffold.md
+++ b/docs/issue-496-emergency-cancel-scaffold.md
@@ -1,0 +1,10 @@
+# Issue 496 Emergency Cancel Scaffold
+
+Tracks implementation for admin-only emergency job cancellation.
+
+Planned scope:
+- Add `admin_emergency_cancel(admin, job_id, return_to_client_bps, emergency_cancel_reason)`.
+- Support active stuck states: Open, InProgress, SubmittedForReview, and Disputed.
+- Split escrowed funds by basis points between client and freelancer.
+- Emit a transparent emergency cancellation event with reason metadata.
+- Add frontend admin form, unit tests, and emergency operations documentation.


### PR DESCRIPTION
Summary
- Scaffold PR for Issue #496: admin-only emergency cancellation for jobs that are stuck, malicious, or otherwise unrecoverable through the normal dispute flow.
- The implementation will add a transparent emergency cancel path with configurable fund distribution and operational documentation.

Issue
- Closes #496

Planned Changes
- Add admin_emergency_cancel(admin, job_id, return_to_client_bps, emergency_cancel_reason).
- Allow emergency cancellation from Open, InProgress, SubmittedForReview, and Disputed states.
- Validate return_to_client_bps is within 0..=10000 and split escrowed funds between client and freelancer accordingly.
- Restrict access to the configured admin and keep the design compatible with admin 2FA if/when enabled.
- Emit an AdminEmergencyCancelled-style event with job id, admin, split, and reason for auditability.
- Add a frontend admin panel form for emergency cancellation.
- Add unit tests for status coverage, split scenarios, invalid bps, unauthorized callers, and completed/cancelled guards.
- Document emergency procedures in docs/OPS_RUNBOOK.md.

Validation
- Scaffold only at PR creation time. Implementation commits and validation results will follow on this branch.

Notes
- Opened as a normal PR, not draft, so maintainers can track the work immediately.