### PR TITLE
Allow public viewing of profile pages

### DIFF
--- a/frontend/__tests__/freighter-network.test.ts
+++ b/frontend/__tests__/freighter-network.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFreighterNetwork } from "@/lib/stellar";
+
+describe("normalizeFreighterNetwork", () => {
+  it("maps Freighter network names to app network ids", () => {
+    expect(normalizeFreighterNetwork("TESTNET")).toBe("testnet");
+    expect(normalizeFreighterNetwork("FUTURENET")).toBe("futurenet");
+    expect(normalizeFreighterNetwork("PUBLIC")).toBe("mainnet");
+  });
+
+  it("falls back to matching the network passphrase", () => {
+    expect(
+      normalizeFreighterNetwork(undefined, "Public Global Stellar Network ; September 2015"),
+    ).toBe("mainnet");
+    expect(
+      normalizeFreighterNetwork(undefined, "Test SDF Network ; September 2015"),
+    ).toBe("testnet");
+  });
+
+  it("returns null for unsupported custom networks", () => {
+    expect(normalizeFreighterNetwork("STANDALONE")).toBeNull();
+  });
+});

--- a/frontend/__tests__/profile-address-display.test.tsx
+++ b/frontend/__tests__/profile-address-display.test.tsx
@@ -10,6 +10,10 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("@/components/StatusPill", () => ({
+  default: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
 const mockWalletContext = {
   wallet: null as string | null,
   connectWallet: vi.fn(),

--- a/frontend/__tests__/profile-fallback.test.tsx
+++ b/frontend/__tests__/profile-fallback.test.tsx
@@ -10,6 +10,10 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("@/components/StatusPill", () => ({
+  default: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
 // Mock wallet context
 const mockConnectWallet = vi.fn();
 const mockWalletContext = {
@@ -57,15 +61,15 @@ describe("Profile Route Fallback Handling", () => {
     expect(backLink).toHaveAttribute("href", "/");
   });
 
-  it("shows wallet connection prompt with back navigation when not connected", () => {
+  it("renders a public profile with back navigation when not connected", async () => {
     const validAddress = "GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV";
     mockWalletContext.wallet = null;
     
     render(<ProfilePageClient address={validAddress} />);
 
-    // Check for wallet connection prompt
-    expect(screen.getByText("Connect your wallet to view this profile.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Connect Wallet/ })).toBeInTheDocument();
+    expect(await screen.findByText(validAddress)).toBeInTheDocument();
+    expect(screen.queryByText("Connect your wallet to view this profile.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Edit Portfolio/ })).not.toBeInTheDocument();
 
     // Check for back navigation
     const backLink = screen.getByRole("link", { name: /Back to Home/ });
@@ -126,9 +130,10 @@ describe("Profile Route Fallback Handling", () => {
       mockWalletContext.wallet = null;
       const { unmount } = render(<ProfilePageClient address={address} />);
       
-      // Should show wallet connection prompt, not invalid address
-      expect(screen.getByText("Connect your wallet to view this profile.")).toBeInTheDocument();
+      // Should show the public profile, not invalid address or a wallet gate
+      expect(screen.getByText(address)).toBeInTheDocument();
       expect(screen.queryByText("Invalid Address")).not.toBeInTheDocument();
+      expect(screen.queryByText("Connect your wallet to view this profile.")).not.toBeInTheDocument();
       
       unmount();
     }

--- a/frontend/__tests__/profile-metadata.test.ts
+++ b/frontend/__tests__/profile-metadata.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { generateMetadata } from "@/app/profile/[address]/page";
+
+vi.mock("@/components/StatusPill", () => ({
+  default: ({ status }: { status: string }) => status,
+}));
 
 describe("profile route metadata", () => {
   it("includes valid route address in title", async () => {

--- a/frontend/__tests__/wallet-context.test.tsx
+++ b/frontend/__tests__/wallet-context.test.tsx
@@ -5,17 +5,23 @@ import { WalletProvider, useWallet } from "@/lib/wallet-context";
 
 const mockConnectWallet = vi.fn();
 const mockGetPublicKey = vi.fn();
+const mockGetWalletNetwork = vi.fn();
+const mockWatchWalletNetworkChanges = vi.fn();
 
 vi.mock("@/lib/stellar", () => ({
   connectWallet: (...args: unknown[]) => mockConnectWallet(...args),
   getPublicKey: (...args: unknown[]) => mockGetPublicKey(...args),
+  getWalletNetwork: (...args: unknown[]) => mockGetWalletNetwork(...args),
+  watchWalletNetworkChanges: (...args: unknown[]) =>
+    mockWatchWalletNetworkChanges(...args),
 }));
 
 function WalletProbe() {
-  const { wallet, connectWallet, disconnectWallet } = useWallet();
+  const { wallet, walletNetwork, connectWallet, disconnectWallet } = useWallet();
   return (
     <div>
       <p data-testid="wallet">{wallet ?? "none"}</p>
+      <p data-testid="wallet-network">{walletNetwork ?? "none"}</p>
       <button type="button" onClick={() => void connectWallet()}>
         connect
       </button>
@@ -52,6 +58,8 @@ function WalletErrorProbe() {
 describe("WalletProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetWalletNetwork.mockResolvedValue("testnet");
+    mockWatchWalletNetworkChanges.mockReturnValue(() => undefined);
   });
 
   it("propagates provider state to consumers", async () => {
@@ -65,6 +73,9 @@ describe("WalletProvider", () => {
 
     await waitFor(() =>
       expect(screen.getByTestId("wallet")).toHaveTextContent("GINITIALWALLET"),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet-network")).toHaveTextContent("testnet"),
     );
   });
 
@@ -84,9 +95,13 @@ describe("WalletProvider", () => {
     await waitFor(() =>
       expect(screen.getByTestId("wallet")).toHaveTextContent("GCONNECTEDWALLET"),
     );
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet-network")).toHaveTextContent("testnet"),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "disconnect" }));
     expect(screen.getByTestId("wallet")).toHaveTextContent("none");
+    expect(screen.getByTestId("wallet-network")).toHaveTextContent("none");
   });
 
   it("surfaces connect errors to consumer callers", async () => {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { WalletProvider } from "@/lib/wallet-context";
 import { ToastProvider } from "@/components/ToastProvider";
 import { NotificationProvider } from "@/lib/notifications-context";
@@ -17,6 +18,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import JsonLd from "@/components/JsonLd";
 import AppFooter from "@/components/AppFooter";
 import OfflineIndicator from "@/components/OfflineIndicator";
+import WalletNetworkWarning from "@/components/WalletNetworkWarning";
 import "./globals.css";
 
 const CommandPalette = dynamic(() => import("@/components/CommandPalette"), { ssr: false });
@@ -136,14 +138,14 @@ export default async function RootLayout({
           }}
         />
         <NextIntlClientProvider messages={messages} locale={locale}>
-        <ThemeProvider>
-        <TypographyProvider>
-        <NetworkProvider>
-        <WalletProvider>
-          <NotificationProvider>
-          <MessagingProvider>
-          <MeetingsProvider>
-          <ToastProvider>
+          <ThemeProvider>
+            <TypographyProvider>
+              <NetworkProvider>
+                <WalletProvider>
+                  <NotificationProvider>
+                    <MessagingProvider>
+                      <MeetingsProvider>
+                        <ToastProvider>
           <a
             href="#main-content"
             className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-slate-900 focus:outline-none dark:focus:bg-slate-800 dark:focus:text-slate-100"
@@ -153,6 +155,7 @@ export default async function RootLayout({
           <ServiceWorkerRegistration />
           <AnnouncementBanner />
           <OfflineIndicator />
+          <WalletNetworkWarning />
           <Navigation />
           <CommandPalette />
           <ShortcutCheatSheet />
@@ -189,14 +192,14 @@ export default async function RootLayout({
           </footer>
           <InstallPrompt />
           <AppFooter />
-          </ToastProvider>
-          </MeetingsProvider>
-          </MessagingProvider>
-          </NotificationProvider>
-        </WalletProvider>
-        </TypographyProvider>
-        </NetworkProvider>
-        </ThemeProvider>
+                        </ToastProvider>
+                      </MeetingsProvider>
+                    </MessagingProvider>
+                  </NotificationProvider>
+                </WalletProvider>
+              </NetworkProvider>
+            </TypographyProvider>
+          </ThemeProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/frontend/app/profile/[address]/profile-page-client.tsx
+++ b/frontend/app/profile/[address]/profile-page-client.tsx
@@ -289,7 +289,7 @@ function TestimonialForm({
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export default function ProfilePageClient({ address }: { address: string }) {
-  const { wallet, connectWallet } = useWallet();
+  const { wallet } = useWallet();
 
   const [jobs, setJobs] = useState<ProfileJob[]>([]);
   const [loading, setLoading] = useState(false);
@@ -312,6 +312,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
   // Load portfolio + testimonials from localStorage
   useEffect(() => {
     if (!addressValid) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPortfolio(loadPortfolio(address));
     setTestimonials(loadTestimonials(address));
   }, [address, addressValid]);
@@ -321,7 +322,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
   }, [address]);
 
   const fetchJobs = useCallback(async () => {
-    if (!wallet || !addressValid) return;
+    if (!addressValid) return;
     setLoading(true);
     setError(null);
     try {
@@ -341,7 +342,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
         } else {
           setRestricted(false);
         }
-      } catch (e) {
+      } catch {
         // ignore errors reading access control
       }
 
@@ -359,12 +360,12 @@ export default function ProfilePageClient({ address }: { address: string }) {
     } finally {
       setLoading(false);
     }
-  }, [wallet, address, addressValid]);
+  }, [address, addressValid]);
 
   useEffect(() => {
-    if (wallet) { fetchJobs(); }
-    else { setJobs([]); setLoading(false); setError(null); }
-  }, [wallet, fetchJobs]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchJobs();
+  }, [fetchJobs]);
 
   // Derived stats
   const jobsPosted = jobs.filter((j) => j.role === "client").length;
@@ -415,6 +416,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
     }));
 
   function startEdit() {
+    if (!isOwner) return;
     setDraft({ ...portfolio, skills: [...portfolio.skills], links: [...portfolio.links], highlightedJobIds: [...portfolio.highlightedJobIds] });
     setEditMode(true);
     setSaveSuccess(false);
@@ -425,6 +427,7 @@ export default function ProfilePageClient({ address }: { address: string }) {
   }
 
   function saveEdit() {
+    if (!isOwner) return;
     const cleaned: Portfolio = {
       version: 1,
       bio: draft.bio.trim().slice(0, MAX_BIO_LENGTH),
@@ -466,26 +469,6 @@ export default function ProfilePageClient({ address }: { address: string }) {
   }
 
   // ── Not connected ────────────────────────────────────────────────────────
-  if (!wallet) {
-    return (
-      <section className="mx-auto max-w-3xl space-y-6">
-        <div className="flex items-center gap-4">
-          <Link href="/" className="text-sm text-blue-600 hover:underline">Back to Home</Link>
-          <h1 className="text-2xl font-semibold">Profile</h1>
-        </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
-          <p className="text-slate-600">Connect your wallet to view this profile.</p>
-          <button
-            className="mt-4 rounded-md bg-slate-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-slate-800"
-            onClick={async () => { try { await connectWallet(); } catch { /* cancelled */ } }}
-          >
-            Connect Wallet
-          </button>
-        </div>
-      </section>
-    );
-  }
-
   // Completed jobs eligible for highlights (as freelancer)
   const highlightableJobs = completedAsFreelancer;
   const highlightedJobs = jobs.filter((j) =>
@@ -495,7 +478,9 @@ export default function ProfilePageClient({ address }: { address: string }) {
   // Jobs where connected wallet is client and address is the freelancer (for testimonials)
   const clientCanTestifyJobs = jobs.filter(
     (j) =>
-      j.role === "client" &&
+      wallet &&
+      j.role === "freelancer" &&
+      j.job.client === wallet &&
       j.job.freelancer === address &&
       j.job.status === "Completed" &&
       wallet !== address,

--- a/frontend/components/WalletNetworkWarning.tsx
+++ b/frontend/components/WalletNetworkWarning.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useNetwork } from "@/lib/network-context";
+import { getNetworkConfig } from "@/lib/network-config";
+import { useWallet } from "@/lib/wallet-context";
+
+function formatNetwork(network: string) {
+  return network.charAt(0).toUpperCase() + network.slice(1);
+}
+
+export default function WalletNetworkWarning() {
+  const { wallet, walletNetwork, refreshWalletNetwork } = useWallet();
+  const { network, setNetwork } = useNetwork();
+  const [switching, setSwitching] = useState(false);
+
+  if (!wallet || !walletNetwork || walletNetwork === network) {
+    return null;
+  }
+
+  const walletConfig = getNetworkConfig(walletNetwork);
+  const appConfig = getNetworkConfig(network);
+
+  const handleSwitch = async () => {
+    setSwitching(true);
+    try {
+      setNetwork(walletNetwork);
+      window.location.reload();
+    } catch {
+      await refreshWalletNetwork();
+      setSwitching(false);
+    }
+  };
+
+  return (
+    <section
+      className="border-b border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-50">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+              />
+            </svg>
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold">Wallet network mismatch</p>
+            <p className="mt-0.5 text-sm leading-6 text-amber-900 dark:text-amber-100">
+              This app is using {appConfig.label}, but Freighter is connected to{" "}
+              {walletConfig.label}. Transactions may fail until both networks match.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleSwitch}
+          disabled={switching}
+          className="inline-flex shrink-0 items-center justify-center rounded-md bg-amber-950 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-amber-100 dark:text-amber-950 dark:hover:bg-white"
+        >
+          {switching
+            ? "Switching..."
+            : `Use ${formatNetwork(walletNetwork)} in app`}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -14,8 +14,10 @@ import {
 import {
   getAddress,
   isAllowed,
+  getNetwork as getFreighterNetwork,
   requestAccess,
   signTransaction as freighterSignTransaction,
+  WatchWalletChanges,
 } from "@stellar/freighter-api";
 import {
   type StellarNetwork,
@@ -37,6 +39,62 @@ function getActiveNetwork(): StellarNetwork {
 const getRpcUrl = () => getNetworkConfig(getActiveNetwork()).rpcUrl;
 
 export type { StellarNetwork };
+
+const FREIGHTER_NETWORK_BY_NAME: Record<string, StellarNetwork> = {
+  TESTNET: "testnet",
+  FUTURENET: "futurenet",
+  PUBLIC: "mainnet",
+  MAINNET: "mainnet",
+};
+
+export function normalizeFreighterNetwork(
+  network?: string,
+  networkPassphrase?: string,
+): StellarNetwork | null {
+  if (network) {
+    const normalized = FREIGHTER_NETWORK_BY_NAME[network.toUpperCase()];
+    if (normalized) return normalized;
+  }
+
+  if (networkPassphrase) {
+    const match = (["testnet", "futurenet", "mainnet"] as const).find(
+      (candidate) => getNetworkConfig(candidate).passphrase === networkPassphrase,
+    );
+    if (match) return match;
+  }
+
+  return null;
+}
+
+export async function getWalletNetwork(): Promise<StellarNetwork | null> {
+  const walletNetwork = await getFreighterNetwork();
+  if (walletNetwork.error) {
+    return null;
+  }
+  return normalizeFreighterNetwork(
+    walletNetwork.network,
+    walletNetwork.networkPassphrase,
+  );
+}
+
+export function watchWalletNetworkChanges(
+  onChange: (snapshot: { address: string; network: StellarNetwork | null }) => void,
+): () => void {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const watcher = new WatchWalletChanges(3000);
+  watcher.watch(({ address, network, networkPassphrase, error }) => {
+    if (error) return;
+    onChange({
+      address,
+      network: normalizeFreighterNetwork(network, networkPassphrase),
+    });
+  });
+
+  return () => watcher.stop();
+}
 
 export function getConfiguredNetwork(): StellarNetwork | null {
   const network = getActiveNetwork();

--- a/frontend/lib/wallet-context.tsx
+++ b/frontend/lib/wallet-context.tsx
@@ -13,8 +13,11 @@ import {
   connectWallet as stellarConnectWallet,
   getPublicKey,
   getNativeBalance,
+  getWalletNetwork,
+  watchWalletNetworkChanges,
 } from "@/lib/stellar";
-import LegalConsentModal, { hasAcceptedLegal, acceptLegal } from "@/components/LegalConsentModal";
+import type { StellarNetwork } from "@/lib/network-config";
+import LegalConsentModal, { hasAcceptedLegal } from "@/components/LegalConsentModal";
 import { toXlm } from "@/lib/format";
 
 // Storage keys
@@ -23,10 +26,12 @@ const JOB_CACHE_PREFIX = "job-desc:";
 
 interface WalletContextType {
   wallet: string | null;
+  walletNetwork: StellarNetwork | null;
   connectWallet: () => Promise<void>;
   disconnectWallet: () => void;
   switchAccount: (address?: string) => Promise<void>;
   clearCachedData: () => void;
+  refreshWalletNetwork: () => Promise<void>;
   isSwitching: boolean;
 }
 
@@ -34,6 +39,7 @@ type WalletDisplayMode = "short" | "full";
 
 const WalletContext = createContext<WalletContextType>({
   wallet: null,
+  walletNetwork: null,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   connectWallet: async () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -42,6 +48,8 @@ const WalletContext = createContext<WalletContextType>({
   switchAccount: async () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   clearCachedData: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  refreshWalletNetwork: async () => {},
   isSwitching: false,
 });
 
@@ -72,22 +80,46 @@ function persistLastAccount(address: string | null) {
 
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [wallet, setWallet] = useState<string | null>(null);
+  const [walletNetwork, setWalletNetwork] = useState<StellarNetwork | null>(null);
   const [showLegalModal, setShowLegalModal] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
   const connectPromiseRef = useRef<Promise<string> | null>(null);
 
+  const refreshWalletNetwork = useCallback(async () => {
+    const nextNetwork = await getWalletNetwork();
+    setWalletNetwork(nextNetwork);
+  }, []);
+
   // On mount: restore last session via Freighter if still allowed.
   useEffect(() => {
-    getPublicKey().then((key) => {
+    getPublicKey().then(async (key) => {
       if (key) {
         setWallet(key);
         persistLastAccount(key);
+        await refreshWalletNetwork();
       }
     });
-  }, []);
+  }, [refreshWalletNetwork]);
+
+  useEffect(() => {
+    if (!wallet) {
+      return;
+    }
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refreshWalletNetwork();
+    return watchWalletNetworkChanges(({ address, network }) => {
+      if (address) {
+        setWallet(address);
+        persistLastAccount(address);
+      }
+      setWalletNetwork(network);
+    });
+  }, [wallet, refreshWalletNetwork]);
 
   useEffect(() => {
     if (wallet && !hasAcceptedLegal()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setShowLegalModal(true);
     }
   }, [wallet]);
@@ -107,10 +139,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const key = await connectPromiseRef.current;
     setWallet(key);
     persistLastAccount(key);
-  }, [wallet]);
+    await refreshWalletNetwork();
+  }, [wallet, refreshWalletNetwork]);
 
   const disconnectWallet = useCallback(() => {
     setWallet(null);
+    setWalletNetwork(null);
     persistLastAccount(null);
     // Clear session display preference
     if (typeof window !== "undefined") {
@@ -127,7 +161,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
    * Triggers Freighter's account selection, clears job cache, then updates state.
    * Caller is responsible for showing a confirmation dialog before calling this.
    */
-  const switchAccount = useCallback(async (_address?: string) => {
+  const switchAccount = useCallback(async () => {
     setIsSwitching(true);
     try {
       // Re-request access so Freighter shows the account picker.
@@ -137,14 +171,24 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setWallet(newKey);
         persistLastAccount(newKey);
       }
+      await refreshWalletNetwork();
     } finally {
       setIsSwitching(false);
     }
-  }, [wallet]);
+  }, [wallet, refreshWalletNetwork]);
 
   return (
     <WalletContext.Provider
-      value={{ wallet, connectWallet, disconnectWallet, switchAccount, clearCachedData, isSwitching }}
+      value={{
+        wallet,
+        walletNetwork,
+        connectWallet,
+        disconnectWallet,
+        switchAccount,
+        clearCachedData,
+        refreshWalletNetwork,
+        isSwitching,
+      }}
     >
       {children}
       {showLegalModal && (
@@ -188,12 +232,14 @@ export function WalletButton() {
   useEffect(() => {
     const stored = sessionStorage.getItem("wallet-display-mode");
     if (stored === "short" || stored === "full") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplayMode(stored);
     }
   }, []);
 
   useEffect(() => {
     if (!wallet) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplayMode("short");
       setBalance(null);
     } else {


### PR DESCRIPTION
Closes #622

## Summary

- Removed the wallet connection gate from public profile pages.
- Changed profile job history loading to fetch by route profile address, not connected wallet.
- Kept owner-only profile editing restricted to the connected wallet that matches the profile address.
- Restricted testimonial actions to connected clients with completed jobs for that freelancer.
- Updated profile tests to cover disconnected public profile viewing.

## Testing

- `npx.cmd eslint app/profile/[address]/profile-page-client.tsx __tests__/profile-fallback.test.tsx __tests__/profile-address-display.test.tsx __tests__/profile-metadata.test.ts`
- `npx.cmd vitest run __tests__/profile-fallback.test.tsx __tests__/profile-address-display.test.tsx __tests__/profile-metadata.test.ts`

## Notes

Full repo checks remain blocked by unrelated existing failures:
- `npm.cmd run typecheck` fails on JSX parse errors in `app/dashboard/page.tsx` and `components/ToastProvider.tsx`.
