### PR TITLE
fix: address tooltips, disputed filter, and token validation (#608, #621, #625)

### DIFF
--- a/frontend/__tests__/dashboard-filter-chips.test.tsx
+++ b/frontend/__tests__/dashboard-filter-chips.test.tsx
@@ -105,6 +105,7 @@ describe("Dashboard filter chip toggling", () => {
       expect(screen.getByRole("button", { name: /Submitted for Review filter, not selected/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /Completed filter, not selected/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /Cancelled filter, not selected/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Disputed filter, not selected/i })).toBeInTheDocument();
     });
   });
 
@@ -246,8 +247,8 @@ describe("Dashboard filter chip toggling", () => {
     fireEvent.click(cancelledFilter);
 
     await waitFor(() => {
-      expect(screen.getByText("No jobs match this filter")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Clear filter" })).toBeInTheDocument();
+      expect(screen.getAllByText("No jobs match this filter").length).toBeGreaterThan(0);
+      expect(screen.getAllByRole("button", { name: "Clear filter" }).length).toBeGreaterThan(0);
     });
   });
 
@@ -275,11 +276,11 @@ describe("Dashboard filter chip toggling", () => {
     fireEvent.click(cancelledFilter);
 
     await waitFor(() => {
-      expect(screen.getByText("No jobs match this filter")).toBeInTheDocument();
+      expect(screen.getAllByText("No jobs match this filter").length).toBeGreaterThan(0);
     });
 
     // Click Clear filter
-    const clearFilterButton = screen.getByRole("button", { name: "Clear filter" });
+    const clearFilterButton = screen.getAllByRole("button", { name: "Clear filter" })[0];
     fireEvent.click(clearFilterButton);
 
     await waitFor(() => {

--- a/frontend/__tests__/post-job-amount-validation.test.tsx
+++ b/frontend/__tests__/post-job-amount-validation.test.tsx
@@ -26,9 +26,34 @@ vi.mock("@/lib/wallet-context", () => ({
 
 vi.mock("@/lib/stellar", () => ({
   getExplorerTxUrl: (hash: string) => `https://example.test/tx/${hash}`,
+  isValidStellarAddress: (address: string) =>
+    /^[GC][A-Z2-7]{55}$/.test(address.trim()),
 }));
 
-const TOKEN_ADDRESS = "GTOKEN000000000000000000000000000000000000000000000000000";
+vi.mock("@/components/RichTextEditor", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    labelId,
+    required,
+  }: {
+    value: string;
+    onChange: (html: string) => void;
+    labelId?: string;
+    required?: boolean;
+  }) => (
+    <textarea
+      aria-labelledby={labelId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      required={required}
+    />
+  ),
+  htmlToPlainText: (html: string) => html.replace(/<[^>]+>/g, "").trim(),
+}));
+
+const TOKEN_ADDRESS = "GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV";
 
 function fillRequiredFields({
   amount,
@@ -57,6 +82,11 @@ describe("Post job amount input validation", () => {
     mockUseWallet.mockReturnValue({
       wallet: "GWALLET000000000000000000000000000000000000000000000000000",
       connectWallet: vi.fn(),
+    });
+    vi.stubGlobal("crypto", {
+      subtle: {
+        digest: vi.fn().mockResolvedValue(new Uint8Array(32).buffer),
+      },
     });
   });
 

--- a/frontend/__tests__/post-job-draft.test.tsx
+++ b/frontend/__tests__/post-job-draft.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@/lib/wallet-context", () => ({
 
 vi.mock("@/lib/stellar", () => ({
   getExplorerTxUrl: (hash: string) => `https://example.test/tx/${hash}`,
+  isValidStellarAddress: (address: string) =>
+    /^[GC][A-Z2-7]{55}$/.test(address.trim()),
 }));
 
 describe("Post-job form: draft saving (FE-71)", () => {

--- a/frontend/__tests__/post-job-form-fields.test.tsx
+++ b/frontend/__tests__/post-job-form-fields.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@/lib/wallet-context", () => ({
 
 vi.mock("@/lib/stellar", () => ({
   getExplorerTxUrl: (hash: string) => `https://example.test/tx/${hash}`,
+  isValidStellarAddress: (address: string) =>
+    /^[GC][A-Z2-7]{55}$/.test(address.trim()),
 }));
 
 describe("Post-job page: form fields presence (#306)", () => {

--- a/frontend/__tests__/post-job-form.test.tsx
+++ b/frontend/__tests__/post-job-form.test.tsx
@@ -28,7 +28,34 @@ vi.mock("@/lib/wallet-context", () => ({
 
 vi.mock("@/lib/stellar", () => ({
   getExplorerTxUrl: (hash: string) => `https://stellar.expert/tx/${hash}`,
+  isValidStellarAddress: (address: string) =>
+    /^[GC][A-Z2-7]{55}$/.test(address.trim()),
 }));
+
+vi.mock("@/components/RichTextEditor", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    labelId,
+    required,
+  }: {
+    value: string;
+    onChange: (html: string) => void;
+    labelId?: string;
+    required?: boolean;
+  }) => (
+    <textarea
+      aria-labelledby={labelId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      required={required}
+    />
+  ),
+  htmlToPlainText: (html: string) => html.replace(/<[^>]+>/g, "").trim(),
+}));
+
+const VALID_TOKEN = "GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV";
 
 describe("Post job form validation", () => {
   beforeEach(() => {
@@ -62,13 +89,46 @@ describe("Post job form validation", () => {
       target: { value: "Build escrow UI" },
     });
     fireEvent.change(screen.getByRole("textbox", { name: /Token Address/ }), {
-      target: { value: "GNATIVE" },
+      target: { value: VALID_TOKEN },
     });
     fireEvent.submit(screen.getByRole("button", { name: "Post Job" }).closest("form")!);
 
     expect(
       await screen.findAllByText("Enter a valid amount with up to 7 decimal places."),
     ).toHaveLength(2);
+    expect(mockPostJob).not.toHaveBeenCalled();
+  });
+
+  it("shows inline feedback for an invalid token address format", async () => {
+    render(<PostJobPage />);
+
+    const tokenInput = screen.getByLabelText(/Token Address/);
+    fireEvent.change(tokenInput, { target: { value: "not-a-stellar-address" } });
+    fireEvent.blur(tokenInput);
+
+    await waitFor(() => {
+      expect(tokenInput).toHaveAttribute("aria-invalid", "true");
+    });
+    expect(document.getElementById("post-job-token-address-error")).toHaveTextContent(
+      /valid Stellar address/i,
+    );
+  });
+
+  it("blocks submit when token address format is invalid", async () => {
+    render(<PostJobPage />);
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: /Amount/ }), {
+      target: { value: "1.25" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: /Job Description/ }), {
+      target: { value: "Build escrow UI" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: /Token Address/ }), {
+      target: { value: "GNATIVE" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: "Post Job" }).closest("form")!);
+
+    expect(await screen.findAllByText(/Enter a valid Stellar address/)).toHaveLength(2);
     expect(mockPostJob).not.toHaveBeenCalled();
   });
 
@@ -83,7 +143,7 @@ describe("Post job form validation", () => {
       target: { value: "  Build escrow UI  " },
     });
     fireEvent.change(screen.getByRole("textbox", { name: /Token Address/ }), {
-      target: { value: "  GNATIVE  " },
+      target: { value: `  ${VALID_TOKEN}  ` },
     });
     fireEvent.submit(screen.getByRole("button", { name: "Post Job" }).closest("form")!);
 
@@ -94,7 +154,7 @@ describe("Post job form validation", () => {
       "0000000000000000000000000000000000000000000000000000000000000000",
       15,
       "0",
-      "GNATIVE",
+      VALID_TOKEN,
     );
   });
 });

--- a/frontend/__tests__/stellar.test.ts
+++ b/frontend/__tests__/stellar.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { truncateAddress, getNetwork, getExplorerTxUrl } from "../lib/stellar";
+import {
+  truncateAddress,
+  getNetwork,
+  getExplorerTxUrl,
+  isValidStellarAddress,
+} from "../lib/stellar";
 
 describe("truncateAddress", () => {
   it("truncates a Stellar address with default 4 chars", () => {
@@ -21,6 +26,43 @@ describe("truncateAddress", () => {
 
   it("returns empty string for empty input", () => {
     expect(truncateAddress("")).toBe("");
+  });
+});
+
+describe("isValidStellarAddress", () => {
+  it("accepts a 56-character G account address", () => {
+    expect(
+      isValidStellarAddress(
+        "GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a 56-character C contract address", () => {
+    expect(
+      isValidStellarAddress(
+        "CABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects short, padded, or invalid-alphabet strings", () => {
+    expect(isValidStellarAddress("GNATIVE")).toBe(false);
+    expect(isValidStellarAddress("not-an-address")).toBe(false);
+    expect(
+      isValidStellarAddress(
+        "GTOKEN000000000000000000000000000000000000000000000000000",
+      ),
+    ).toBe(false);
+    expect(isValidStellarAddress("")).toBe(false);
+  });
+
+  it("trims whitespace before validating", () => {
+    expect(
+      isValidStellarAddress(
+        "  GABC7DEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV  ",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/frontend/__tests__/tooltip-truncated-address.test.tsx
+++ b/frontend/__tests__/tooltip-truncated-address.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Tooltip from "@/components/Tooltip";
+import TruncatedAddress from "@/components/TruncatedAddress";
+
+const FULL_ADDRESS = "GALVPSP4DOAQTNBPRYMHFJNRXFJPCJQQGFPRP5DBQKXGYGDHMHXBVHGF";
+
+describe("Tooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows content after the hover delay and hides on leave", () => {
+    render(
+      <Tooltip content="Full value" delay={400}>
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+
+    const tip = screen.getByRole("tooltip", { hidden: true });
+    expect(tip).toHaveClass("opacity-0");
+
+    fireEvent.mouseEnter(tip.parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(399);
+    });
+    expect(tip).toHaveClass("opacity-0");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(tip).toHaveClass("opacity-100");
+
+    fireEvent.mouseLeave(tip.parentElement!);
+    expect(tip).toHaveClass("opacity-0");
+  });
+
+  it("shows on keyboard focus", () => {
+    render(
+      <Tooltip content="Focused tip" delay={200}>
+        <span>Focus me</span>
+      </Tooltip>,
+    );
+
+    const tip = screen.getByRole("tooltip", { hidden: true });
+    const trigger = tip.previousElementSibling as HTMLElement;
+    fireEvent.focus(trigger.parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(tip).toHaveClass("opacity-100");
+  });
+});
+
+describe("TruncatedAddress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders truncated text and reveals the full address in a tooltip", () => {
+    render(<TruncatedAddress address={FULL_ADDRESS} />);
+
+    expect(screen.getByText("GALVPS...VHGF")).toBeInTheDocument();
+    expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent(FULL_ADDRESS);
+  });
+
+  it("renders short addresses without a tooltip trigger truncation", () => {
+    render(<TruncatedAddress address="GTOKEN" />);
+    expect(screen.getByText("GTOKEN")).toBeInTheDocument();
+    expect(screen.queryByRole("tooltip", { hidden: true })).not.toBeInTheDocument();
+  });
+
+  it("renders the empty label when address is blank", () => {
+    render(<TruncatedAddress address="" emptyLabel="N/A" />);
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -18,6 +18,7 @@ import EmptyState from "@/components/EmptyState";
 import ErrorBanner from "@/components/ErrorBanner";
 import StatusPill from "@/components/StatusPill";
 import SectionCard from "@/components/SectionCard";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { formatDeadline, toXlm } from "@/lib/format";
 import { isConfirmSuppressed, CONFIRM_KEYS } from "@/lib/confirm-prefs";
 import { useWallet } from "@/lib/wallet-context";
@@ -285,7 +286,7 @@ export default function AdminPage() {
         <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
           <p className="font-medium text-red-800">Unauthorized</p>
           <p className="mt-1 text-sm text-red-600">
-            Your wallet ({wallet.slice(0, 6)}...{wallet.slice(-4)}) is not the
+            Your wallet (<TruncatedAddress address={wallet} />) is not the
             contract admin.
           </p>
         </div>
@@ -629,10 +630,14 @@ export default function AdminPage() {
                       <StatusPill status={job.status} />
                     </td>
                     <td className="py-2 pr-4 font-mono text-xs">
-                      {job.client.slice(0, 8)}...
+                      <TruncatedAddress address={job.client} />
                     </td>
                     <td className="py-2 pr-4 font-mono text-xs">
-                      {job.freelancer ? `${job.freelancer.slice(0, 8)}...` : "-"}
+                      {job.freelancer ? (
+                        <TruncatedAddress address={job.freelancer} />
+                      ) : (
+                        "-"
+                      )}
                     </td>
                     <td className="py-2 pr-4 text-right">
                       <span className="inline-flex min-w-0 items-baseline justify-end gap-1">

--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { getJob } from "@/lib/contract";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { formatDeadline, toXlm } from "@/lib/format";
 import type { Job } from "@/lib/types";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 
 interface JobEntry {
@@ -12,8 +13,13 @@ interface JobEntry {
   job: Job;
 }
 
-function Field({ label, values }: { label: string; values: string[] }) {
-  const allSame = values.every((v) => v === values[0]);
+function Field({ label, values }: { label: string; values: ReactNode[] }) {
+  const stringValues = values.map((v) =>
+    typeof v === "string" || typeof v === "number" ? String(v) : null,
+  );
+  const comparable = stringValues.every((v) => v !== null);
+  const allSame =
+    comparable && stringValues.every((v) => v === stringValues[0]);
   return (
     <tr>
       <th
@@ -26,7 +32,9 @@ function Field({ label, values }: { label: string; values: string[] }) {
         <td
           key={index}
           className={`border border-slate-200 px-3 py-2 text-sm ${
-            !allSame && values.length > 1 ? "bg-yellow-50 font-semibold" : ""
+            !allSame && comparable && values.length > 1
+              ? "bg-yellow-50 font-semibold"
+              : ""
           }`}
         >
           {value}
@@ -187,16 +195,21 @@ export default function ComparePage() {
                 />
                 <Field
                   label="Client"
-                  values={entries.map(({ job }) =>
-                    `${job.client.slice(0, 8)}…${job.client.slice(-4)}`,
-                  )}
+                  values={entries.map(({ job }) => (
+                    <TruncatedAddress key={job.client} address={job.client} />
+                  ))}
                 />
                 <Field
                   label="Freelancer"
                   values={entries.map(({ job }) =>
-                    job.freelancer
-                      ? `${job.freelancer.slice(0, 8)}…${job.freelancer.slice(-4)}`
-                      : "Unassigned",
+                    job.freelancer ? (
+                      <TruncatedAddress
+                        key={job.freelancer}
+                        address={job.freelancer}
+                      />
+                    ) : (
+                      "Unassigned"
+                    ),
                   )}
                 />
                 <Field
@@ -207,9 +220,9 @@ export default function ComparePage() {
                 />
                 <Field
                   label="Token"
-                  values={entries.map(({ job }) =>
-                    `${job.token.slice(0, 8)}…${job.token.slice(-4)}`,
-                  )}
+                  values={entries.map(({ job }) => (
+                    <TruncatedAddress key={job.token} address={job.token} />
+                  ))}
                 />
               </tbody>
             </table>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -20,6 +20,7 @@ import JobCardSkeleton from "@/components/JobCardSkeleton";
 import NoResultsState from "@/components/NoResultsState";
 import SectionCard from "@/components/SectionCard";
 import StatusPill from "@/components/StatusPill";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { useToast } from "@/components/ToastProvider";
 import { useNotifications, getEventLabel } from "@/lib/notifications-context";
 import { formatDeadline, toXlm } from "@/lib/format";
@@ -40,6 +41,7 @@ const STATUS_OPTIONS: JobStatus[] = [
   "SubmittedForReview",
   "Completed",
   "Cancelled",
+  "Disputed",
 ];
 
 const EVENT_DOT: Record<string, string> = {
@@ -510,7 +512,7 @@ export default function DashboardPage() {
             onRequestAction={requestDashAction}
             onClearFilter={() => setStatusFilter("All")}
             selectedJobs={selectedJobs}
-            onToggleSelect={(id) => {
+            onToggleBatchSelect={(id) => {
               setSelectedJobs((prev) => {
                 const next = new Set(prev);
                 if (next.has(id)) next.delete(id);
@@ -577,7 +579,12 @@ export default function DashboardPage() {
                             <span className="shrink-0">XLM</span>
                           </p>
                           <p className="truncate font-mono text-xs text-slate-400">
-                            Token: {job.token ? `${job.token.slice(0, 8)}...${job.token.slice(-4)}` : "N/A"}
+                            Token:{" "}
+                            {job.token ? (
+                              <TruncatedAddress address={job.token} className="font-mono text-xs text-slate-400" />
+                            ) : (
+                              "N/A"
+                            )}
                           </p>
                           <p>
                             {(() => {
@@ -704,7 +711,7 @@ function JobSection({
   onRequestAction,
   onClearFilter,
   selectedJobs,
-  onToggleSelect,
+  onToggleBatchSelect,
   onBatchApprove,
   batchLoading,
   selectedJobIds = new Set(),
@@ -726,35 +733,9 @@ function JobSection({
   onRequestAction: (type: PendingDashAction["type"], jobId: number, amountXlm: string) => void;
   onClearFilter: () => void;
   selectedJobs?: Set<number>;
-  onToggleSelect?: (id: number) => void;
+  onToggleBatchSelect?: (id: number) => void;
   onBatchApprove?: () => void;
   batchLoading?: boolean;
-}) {
-  const pendingReviewIds = allJobs
-    .filter((j) => j.job.status === "SubmittedForReview")
-    .map((j) => j.id);
-  const hasPendingReview = pendingReviewIds.length > 0;
-
-  return (
-    <div>
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">{title}</h2>
-          <p className="mb-3 text-sm text-slate-500">{subtitle}</p>
-        </div>
-        {role === "client" && hasPendingReview && (
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">
-              {selectedJobs?.size ?? 0} of {pendingReviewIds.length} selected
-            </span>
-            <button
-              type="button"
-              onClick={onBatchApprove}
-              disabled={!selectedJobs || selectedJobs.size === 0 || batchLoading}
-              className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {batchLoading ? "Approving..." : `Approve Selected (${selectedJobs?.size ?? 0})`}
-            </button>
   selectedJobIds?: Set<number>;
   onToggleSelect?: (id: number) => void;
   onSelectAll?: () => void;
@@ -762,9 +743,14 @@ function JobSection({
   onBulkCancel?: () => void;
   bulkCancelProgress?: { done: number; total: number; failed: number[] } | null;
 }) {
+  const pendingReviewIds = allJobs
+    .filter((j) => j.job.status === "SubmittedForReview")
+    .map((j) => j.id);
+  const hasPendingReview = pendingReviewIds.length > 0;
   const openClientJobs = role === "client" ? jobs.filter((j) => j.job.status === "Open") : [];
   const selectionCount = openClientJobs.filter((j) => selectedJobIds.has(j.id)).length;
-  const allOpenSelected = openClientJobs.length > 0 && openClientJobs.every((j) => selectedJobIds.has(j.id));
+  const allOpenSelected =
+    openClientJobs.length > 0 && openClientJobs.every((j) => selectedJobIds.has(j.id));
 
   return (
     <div>
@@ -773,28 +759,48 @@ function JobSection({
           <h2 className="text-lg font-semibold">{title}</h2>
           <p className="text-sm text-slate-500">{subtitle}</p>
         </div>
-        {/* Bulk cancel controls — client only, at least 1 open job */}
-        {role === "client" && openClientJobs.length > 0 && (
-          <div className="flex items-center gap-2">
-            <button
-              className="text-xs text-slate-500 underline underline-offset-2 hover:text-slate-800"
-              onClick={allOpenSelected ? onDeselectAll : onSelectAll}
-            >
-              {allOpenSelected ? "Deselect all" : "Select all open"}
-            </button>
-            {selectionCount >= 2 && (
+        <div className="flex flex-wrap items-center gap-2">
+          {role === "client" && hasPendingReview && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400">
+                {selectedJobs?.size ?? 0} of {pendingReviewIds.length} selected
+              </span>
               <button
-                disabled={!!bulkCancelProgress}
-                className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-60 transition-colors"
-                onClick={onBulkCancel}
+                type="button"
+                onClick={onBatchApprove}
+                disabled={!selectedJobs || selectedJobs.size === 0 || batchLoading}
+                className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {bulkCancelProgress
-                  ? `Cancelling… ${bulkCancelProgress.done}/${bulkCancelProgress.total}`
-                  : `Cancel selected (${selectionCount})`}
+                {batchLoading
+                  ? "Approving..."
+                  : `Approve Selected (${selectedJobs?.size ?? 0})`}
               </button>
-            )}
-          </div>
-        )}
+            </div>
+          )}
+          {role === "client" && openClientJobs.length > 0 && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="text-xs text-slate-500 underline underline-offset-2 hover:text-slate-800"
+                onClick={allOpenSelected ? onDeselectAll : onSelectAll}
+              >
+                {allOpenSelected ? "Deselect all" : "Select all open"}
+              </button>
+              {selectionCount >= 2 && (
+                <button
+                  type="button"
+                  disabled={!!bulkCancelProgress}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-60 transition-colors"
+                  onClick={onBulkCancel}
+                >
+                  {bulkCancelProgress
+                    ? `Cancelling... ${bulkCancelProgress.done}/${bulkCancelProgress.total}`
+                    : `Cancel selected (${selectionCount})`}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
       </div>
       {jobs.length === 0 ? (
         filterActive && allJobs.length > 0 ? (
@@ -805,14 +811,26 @@ function JobSection({
             onAction={onClearFilter}
           />
         ) : (
-          <EmptyState
-            title="No jobs yet"
-            description="No jobs match this filter yet."
-          />
+          <EmptyState title="No jobs yet" description="No jobs match this filter yet." />
         )
       ) : (
-          <ul className="grid list-none gap-4 sm:grid-cols-2" aria-label={title}>
-            {jobs.map(({ id, job }) => (
+        <ul className="grid list-none gap-4 sm:grid-cols-2" aria-label={title}>
+          {jobs.map(({ id, job }) => {
+            const canBulkCancel = job.status === "Open" && role === "client";
+            const canBatchApprove = job.status === "SubmittedForReview" && role === "client";
+            const isSelected = canBulkCancel
+              ? selectedJobIds.has(id)
+              : canBatchApprove
+                ? (selectedJobs?.has(id) ?? false)
+                : false;
+            const toggle =
+              canBulkCancel
+                ? onToggleSelect
+                : canBatchApprove
+                  ? onToggleBatchSelect
+                  : undefined;
+
+            return (
               <li key={id}>
                 <JobCard
                   id={id}
@@ -821,29 +839,14 @@ function JobSection({
                   role={role}
                   isLoading={actionLoading === id}
                   onAction={onAction}
-                  onRequestCancel={onRequestCancel}
-                  isSelected={selectedJobs?.has(id) ?? false}
-                  onToggleSelect={role === "client" ? onToggleSelect : undefined}
+                  onRequestAction={onRequestAction}
+                  isSelected={isSelected}
+                  onToggleSelect={toggle}
+                  selectMode={canBulkCancel ? "cancel" : canBatchApprove ? "approve" : undefined}
                 />
               </li>
-            ))}
-          </ul>
-        <ul className="grid list-none gap-4 sm:grid-cols-2" aria-label={title}>
-          {jobs.map(({ id, job }) => (
-            <li key={id}>
-              <JobCard
-                id={id}
-                job={job}
-                wallet={wallet}
-                role={role}
-                isLoading={actionLoading === id}
-                onAction={onAction}
-                onRequestAction={onRequestAction}
-                isSelected={selectedJobIds.has(id)}
-                onToggleSelect={job.status === "Open" && role === "client" ? onToggleSelect : undefined}
-              />
-            </li>
-          ))}
+            );
+          })}
         </ul>
       )}
     </div>
@@ -857,11 +860,10 @@ function JobCard({
   role,
   isLoading,
   onAction,
-  onRequestCancel,
-  isSelected,
   onRequestAction,
   isSelected = false,
   onToggleSelect,
+  selectMode,
 }: {
   id: number;
   job: Job;
@@ -869,35 +871,37 @@ function JobCard({
   role: "client" | "freelancer";
   isLoading: boolean;
   onAction: (fn: () => Promise<unknown>, jobId: number, notification?: { event: NotificationEvent; message: string }) => Promise<void>;
-  onRequestCancel: (jobId: number) => void;
   onRequestAction: (type: PendingDashAction["type"], jobId: number, amountXlm: string) => void;
   isSelected?: boolean;
   onToggleSelect?: (id: number) => void;
+  selectMode?: "cancel" | "approve";
 }) {
   const actions = getActions(id, job, wallet, role);
   const amountXlm = `${toXlm(job.amount)} XLM`;
+  const ringClass =
+    isSelected && selectMode === "approve"
+      ? "ring-2 ring-emerald-400"
+      : isSelected
+        ? "ring-2 ring-red-400"
+        : "";
 
   return (
-    <article className={`interactive-card h-full p-4 ${isSelected ? "ring-2 ring-emerald-400" : ""}`}>
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2">
-          {onToggleSelect && job.status === "SubmittedForReview" && (
-            <input
-              type="checkbox"
-              checked={isSelected ?? false}
-              onChange={() => onToggleSelect(id)}
-              className="h-4 w-4 rounded border-slate-300 text-emerald-600"
-              aria-label={`Select Job #${id} for batch approval`}
-    <article className={`interactive-card h-full p-4 ${isSelected ? "ring-2 ring-red-400" : ""}`}>
+    <article className={`interactive-card h-full p-4 ${ringClass}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
           {onToggleSelect && (
             <input
               type="checkbox"
-              aria-label={`Select Job #${id} for bulk cancellation`}
+              aria-label={
+                selectMode === "approve"
+                  ? `Select Job #${id} for batch approval`
+                  : `Select Job #${id} for bulk cancellation`
+              }
               checked={isSelected}
               onChange={() => onToggleSelect(id)}
-              className="h-4 w-4 rounded border-slate-300 accent-red-600 cursor-pointer"
+              className={`h-4 w-4 rounded border-slate-300 cursor-pointer ${
+                selectMode === "approve" ? "text-emerald-600" : "accent-red-600"
+              }`}
             />
           )}
           <h3 className="font-medium">Job #{id}</h3>
@@ -912,7 +916,12 @@ function JobCard({
           <span className="shrink-0">XLM</span>
         </p>
         <p className="truncate font-mono text-xs text-slate-400">
-          Token: {job.token ? `${job.token.slice(0, 8)}...${job.token.slice(-4)}` : "N/A"}
+          Token:{" "}
+          {job.token ? (
+            <TruncatedAddress address={job.token} className="font-mono text-xs text-slate-400" />
+          ) : (
+            "N/A"
+          )}
         </p>
         <p>
           {(() => {
@@ -922,16 +931,19 @@ function JobCard({
           })()}
         </p>
         {role === "client" && job.freelancer && (
-          <p className="truncate">Freelancer: {job.freelancer}</p>
+          <p className="truncate">
+            Freelancer: <TruncatedAddress address={job.freelancer} />
+          </p>
         )}
         {role === "freelancer" && (
-          <p className="truncate">Client: {job.client}</p>
+          <p className="truncate">
+            Client: <TruncatedAddress address={job.client} />
+          </p>
         )}
       </div>
       {actions.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">
           {actions.map((action) => {
-            // Actions that need a confirmation dialog
             const needsConfirm =
               action.label === "Cancel Job" ||
               action.label === "Approve Work" ||

--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -6,6 +6,7 @@ import LoadingState from "@/components/LoadingState";
 import { useToast } from "@/components/ToastProvider";
 import StatusPill from "@/components/StatusPill";
 import ShareButton from "@/components/ShareButton";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import RichTextRenderer, { isRichText, PlainTextRenderer } from "@/components/RichTextRenderer";
 import { useNotifications } from "@/lib/notifications-context";
 import { acceptJob, approveWork, cancelJob, freelancerCancelJob, getDescriptionCid, getJob, submitWork } from "@/lib/contract";
@@ -548,7 +549,11 @@ export default function JobDetailPage() {
         <p>
           <strong>Token:</strong>{" "}
           <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">
-            {job.token ? `${job.token.slice(0, 8)}...${job.token.slice(-4)}` : "N/A"}
+            {job.token ? (
+              <TruncatedAddress address={job.token} className="font-mono text-xs" />
+            ) : (
+              "N/A"
+            )}
           </code>
         </p>
         <div>

--- a/frontend/app/meetings/page.tsx
+++ b/frontend/app/meetings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { useMeetings, type Meeting, type MeetingStatus } from "@/lib/meetings-context";
 import { useWallet } from "@/lib/wallet-context";
 import Link from "next/link";
@@ -165,7 +166,11 @@ function MeetingCard({
           </div>
           <p className="mt-0.5 text-xs text-slate-500">
             Job <Link href={`/job/${meeting.jobId}`} className="text-blue-600 hover:underline">#{meeting.jobId}</Link>
-            {" "}· {meeting.proposer === wallet ? "You proposed" : `Proposed by ${meeting.proposer.slice(0, 8)}...`}
+            {" "}· {meeting.proposer === wallet ? "You proposed" : (
+              <>
+                Proposed by <TruncatedAddress address={meeting.proposer} />
+              </>
+            )}
           </p>
           {meeting.selectedSlot && (
             <p className="mt-1 text-xs text-slate-700">

--- a/frontend/app/messages/[address]/page.tsx
+++ b/frontend/app/messages/[address]/page.tsx
@@ -14,6 +14,7 @@ import { useWallet } from "@/lib/wallet-context";
 import { useMessaging } from "@/lib/messaging-context";
 import CallButton from "@/components/CallButton";
 import CallHistory from "@/components/CallHistory";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import {
   loadThread,
   sendMessage,
@@ -422,9 +423,12 @@ export default function ConversationPage() {
           <Link
             href={`/profile/${peerAddress}`}
             className="block truncate font-mono text-sm font-semibold text-slate-900 hover:underline"
-            title={peerAddress}
           >
-            {shortAddr(peerAddress)}
+            <TruncatedAddress
+              address={peerAddress}
+              className="font-mono text-sm font-semibold text-slate-900"
+              focusable={false}
+            />
           </Link>
           <p className="truncate text-[10px] text-slate-400">{peerAddress}</p>
         </div>

--- a/frontend/app/messages/page.tsx
+++ b/frontend/app/messages/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { useWallet } from "@/lib/wallet-context";
 import { useMessaging } from "@/lib/messaging-context";
 import {
@@ -76,7 +77,11 @@ function ConversationRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
             <span className={`truncate text-sm font-mono ${convo.unreadCount > 0 ? "font-semibold text-slate-900" : "font-medium text-slate-700"}`}>
-              {shortAddr(convo.peerAddress)}
+              <TruncatedAddress
+                address={convo.peerAddress}
+                className={`font-mono text-sm ${convo.unreadCount > 0 ? "font-semibold text-slate-900" : "font-medium text-slate-700"}`}
+                focusable={false}
+              />
             </span>
             <span className="shrink-0 text-xs text-slate-400">
               {formatMessageTime(convo.lastMessageAt)}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,6 +6,7 @@ import InfoTooltip from "@/components/InfoTooltip";
 import NoResultsState from "@/components/NoResultsState";
 import JobCardSkeleton from "@/components/JobCardSkeleton";
 import SectionCard from "@/components/SectionCard";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import ComparisonBar from "@/components/ComparisonBar";
 import JobFilterPanel, { DEFAULT_FILTERS, type JobFilters } from "@/components/JobFilterPanel";
 import { acceptJob, getDescriptionCid, getJob, getJobCount } from "@/lib/contract";
@@ -911,7 +912,12 @@ export default function HomePage() {
                     {formatXlmWithFiat(job.amount, fiatCurrency, fiatRates?.rates)}
                   </p>
                   <p className="mt-0.5 truncate font-mono text-xs text-slate-400">
-                    Token: {job.token ? `${job.token.slice(0, 8)}...${job.token.slice(-4)}` : "N/A"}
+                    Token:{" "}
+                    {job.token ? (
+                      <TruncatedAddress address={job.token} className="font-mono text-xs text-slate-400" />
+                    ) : (
+                      "N/A"
+                    )}
                   </p>
                   <p className="mt-1 line-clamp-2 text-sm text-slate-700">
                     {getDescription(job.description_hash)}

--- a/frontend/app/post-job/page.tsx
+++ b/frontend/app/post-job/page.tsx
@@ -4,7 +4,7 @@ import { getDescPayloadMax, postJob, storeDescriptionCid } from "@/lib/contract"
 import { uploadToIpfs } from "@/lib/ipfs-service";
 import ErrorBanner from "@/components/ErrorBanner";
 import RichTextEditor, { htmlToPlainText } from "@/components/RichTextEditor";
-import { getExplorerTxUrl } from "@/lib/stellar";
+import { getExplorerTxUrl, isValidStellarAddress } from "@/lib/stellar";
 import { useWallet } from "@/lib/wallet-context";
 import { useEffect, useId, useRef, useState } from "react";
 import {
@@ -323,6 +323,9 @@ export default function PostJobPage() {
             }
             if (!tokenAddress.trim()) {
               nextFieldErrors.tokenAddress = "Token address is required.";
+            } else if (!isValidStellarAddress(tokenAddress)) {
+              nextFieldErrors.tokenAddress =
+                "Enter a valid Stellar address (G... or C..., 56 characters).";
             }
             if (Object.keys(nextFieldErrors).length > 0) {
               setFieldErrors(nextFieldErrors);
@@ -473,13 +476,31 @@ export default function PostJobPage() {
         <label className="block text-sm font-medium">
           Token Address
           <input
-            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 font-mono text-xs"
+            className={`mt-1 w-full rounded-md border px-3 py-2 font-mono text-xs ${
+              fieldErrors.tokenAddress
+                ? "border-red-400 focus:border-red-500 focus:outline-red-500"
+                : "border-slate-300"
+            }`}
             type="text"
             value={tokenAddress}
             onChange={(e) => {
               setTokenAddress(e.target.value);
               setFieldErrors((current) => ({ ...current, tokenAddress: undefined }));
             }}
+            onBlur={(e) => {
+              const trimmed = e.currentTarget.value.trim();
+              if (!trimmed) return;
+              if (!isValidStellarAddress(trimmed)) {
+                setFieldErrors((current) => ({
+                  ...current,
+                  tokenAddress:
+                    "Enter a valid Stellar address (G... or C..., 56 characters).",
+                }));
+              }
+            }}
+            placeholder="G... or C... (56 characters)"
+            spellCheck={false}
+            autoComplete="off"
             aria-invalid={Boolean(fieldErrors.tokenAddress)}
             aria-describedby={
               fieldErrors.tokenAddress ? "post-job-token-address-error" : undefined

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -5,6 +5,7 @@ import ErrorBanner from "@/components/ErrorBanner";
 import NoResultsState from "@/components/NoResultsState";
 import SectionCard from "@/components/SectionCard";
 import TransactionRowSkeleton from "@/components/TransactionRowSkeleton";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { getJob, getJobCount } from "@/lib/contract";
 import { useWallet } from "@/lib/wallet-context";
 import {
@@ -49,11 +50,6 @@ function formatDate(ts: number): { date: string; time: string } {
       minute: "2-digit",
     }),
   };
-}
-
-function shortenAddress(address: string | null): string {
-  if (!address) return "—";
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
 function sumXlm(txns: Transaction[]): string {
@@ -475,12 +471,14 @@ function TransactionRow({ tx }: { tx: Transaction }) {
 
       {/* Counterparty */}
       <td className="py-3 pr-4">
-        <span
-          className="font-mono text-xs text-slate-500"
-          title={tx.counterparty ?? undefined}
-        >
-          {shortenAddress(tx.counterparty)}
-        </span>
+        {tx.counterparty ? (
+          <TruncatedAddress
+            address={tx.counterparty}
+            className="font-mono text-xs text-slate-500"
+          />
+        ) : (
+          <span className="font-mono text-xs text-slate-500">—</span>
+        )}
       </td>
 
       {/* Status */}

--- a/frontend/components/CallHistory.tsx
+++ b/frontend/components/CallHistory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { loadCallHistory, type CallRecord } from "@/lib/calling";
 
 function formatDuration(ms: number): string {
@@ -13,10 +14,6 @@ function formatDuration(ms: number): string {
 
 function formatTime(ts: number): string {
   return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-function shortAddr(addr: string): string {
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
 }
 
 interface CallHistoryProps {

--- a/frontend/components/CallOverlay.tsx
+++ b/frontend/components/CallOverlay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { useModalFocusTrap } from "@/lib/modal";
 import { getDailyUrl, saveCallRecord, updateCallRecord, type CallType } from "@/lib/calling";
 
@@ -66,7 +67,8 @@ export default function CallOverlay({
         {/* Controls bar */}
         <div className="absolute -top-12 left-0 right-0 flex items-center justify-between z-10">
           <span className="text-sm text-white/70">
-            {callType === "video" ? "Video call" : "Voice call"} with {peerAddress.slice(0, 8)}...
+            {callType === "video" ? "Video call" : "Voice call"} with{" "}
+            <TruncatedAddress address={peerAddress} className="font-mono text-sm text-white/70" />
           </span>
           <div className="flex gap-2">
             <button

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+type TooltipProps = {
+  content: ReactNode;
+  children: ReactNode;
+  /** Delay in ms before showing on hover/focus. Default 400. */
+  delay?: number;
+  /** Preferred placement; flips when clipped by the viewport. Default "top". */
+  placement?: TooltipPlacement;
+  className?: string;
+  contentClassName?: string;
+  /**
+   * When true (default), the trigger is keyboard-focusable.
+   * Set false when nested inside an already-focusable control (e.g. a button).
+   */
+  focusable?: boolean;
+};
+
+const GAP = 8;
+
+function computePlacement(
+  trigger: DOMRect,
+  tip: DOMRect,
+  preferred: TooltipPlacement,
+): TooltipPlacement {
+  const space = {
+    top: trigger.top,
+    bottom: window.innerHeight - trigger.bottom,
+    left: trigger.left,
+    right: window.innerWidth - trigger.right,
+  };
+
+  const fits: Record<TooltipPlacement, boolean> = {
+    top: space.top >= tip.height + GAP,
+    bottom: space.bottom >= tip.height + GAP,
+    left: space.left >= tip.width + GAP,
+    right: space.right >= tip.width + GAP,
+  };
+
+  if (fits[preferred]) return preferred;
+
+  const order: TooltipPlacement[] =
+    preferred === "left" || preferred === "right"
+      ? ["right", "left", "top", "bottom"]
+      : ["top", "bottom", "right", "left"];
+
+  return order.find((p) => fits[p]) ?? preferred;
+}
+
+function placementClasses(placement: TooltipPlacement): string {
+  switch (placement) {
+    case "bottom":
+      return "top-full left-1/2 mt-2 -translate-x-1/2";
+    case "left":
+      return "right-full top-1/2 mr-2 -translate-y-1/2";
+    case "right":
+      return "left-full top-1/2 ml-2 -translate-y-1/2";
+    case "top":
+    default:
+      return "bottom-full left-1/2 mb-2 -translate-x-1/2";
+  }
+}
+
+/**
+ * Reusable tooltip — shows on hover (with delay) and keyboard focus.
+ * Placement flips when the preferred side would overflow the viewport.
+ */
+export default function Tooltip({
+  content,
+  children,
+  delay = 400,
+  placement = "top",
+  className = "",
+  contentClassName = "",
+  focusable = true,
+}: TooltipProps) {
+  const tooltipId = useId();
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const tipRef = useRef<HTMLSpanElement>(null);
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [open, setOpen] = useState(false);
+  const [resolvedPlacement, setResolvedPlacement] =
+    useState<TooltipPlacement>(placement);
+
+  const clearShowTimer = useCallback(() => {
+    if (showTimer.current) {
+      clearTimeout(showTimer.current);
+      showTimer.current = null;
+    }
+  }, []);
+
+  const scheduleShow = useCallback(() => {
+    clearShowTimer();
+    showTimer.current = setTimeout(() => setOpen(true), delay);
+  }, [clearShowTimer, delay]);
+
+  const hide = useCallback(() => {
+    clearShowTimer();
+    setOpen(false);
+  }, [clearShowTimer]);
+
+  useEffect(() => () => clearShowTimer(), [clearShowTimer]);
+
+  useLayoutEffect(() => {
+    if (!open || !rootRef.current || !tipRef.current) return;
+    const trigger = rootRef.current.getBoundingClientRect();
+    const tip = tipRef.current.getBoundingClientRect();
+    setResolvedPlacement(computePlacement(trigger, tip, placement));
+  }, [open, placement, content]);
+
+  return (
+    <span
+      ref={rootRef}
+      className={`relative inline-flex max-w-full ${className}`.trim()}
+      onMouseEnter={scheduleShow}
+      onMouseLeave={hide}
+      onFocus={scheduleShow}
+      onBlur={hide}
+    >
+      <span
+        tabIndex={focusable ? 0 : undefined}
+        className="inline-flex max-w-full outline-none"
+        aria-describedby={open ? tooltipId : undefined}
+      >
+        {children}
+      </span>
+      <span
+        ref={tipRef}
+        id={tooltipId}
+        role="tooltip"
+        className={[
+          "pointer-events-none absolute z-30 max-w-xs break-all rounded-md bg-slate-900 px-2.5 py-1.5 font-mono text-xs leading-5 text-white shadow-lg transition-opacity duration-150",
+          placementClasses(resolvedPlacement),
+          open ? "opacity-100" : "opacity-0",
+          contentClassName,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}

--- a/frontend/components/TruncatedAddress.tsx
+++ b/frontend/components/TruncatedAddress.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Tooltip from "@/components/Tooltip";
+import { truncateAddress } from "@/lib/stellar";
+
+type TruncatedAddressProps = {
+  address: string;
+  /** Chars kept on each end after the prefix offset used by truncateAddress. Default 4. */
+  chars?: number;
+  className?: string;
+  /** Shown when address is empty. Default "N/A". */
+  emptyLabel?: string;
+  /** Pass false when nested inside a focusable control. Default true. */
+  focusable?: boolean;
+};
+
+/**
+ * Displays a truncated Stellar address with a tooltip revealing the full value
+ * on hover (delayed) or keyboard focus.
+ */
+export default function TruncatedAddress({
+  address,
+  chars = 4,
+  className = "font-mono text-xs",
+  emptyLabel = "N/A",
+  focusable = true,
+}: TruncatedAddressProps) {
+  if (!address) {
+    return <span className={className}>{emptyLabel}</span>;
+  }
+
+  const truncated = truncateAddress(address, chars);
+
+  if (truncated === address) {
+    return <span className={className}>{address}</span>;
+  }
+
+  return (
+    <Tooltip content={address} focusable={focusable}>
+      <span className={`cursor-default ${className}`.trim()}>{truncated}</span>
+    </Tooltip>
+  );
+}

--- a/frontend/components/WalletMenu.tsx
+++ b/frontend/components/WalletMenu.tsx
@@ -6,7 +6,9 @@ import {
   useEffect,
   useCallback,
 } from "react";
+import TruncatedAddress from "@/components/TruncatedAddress";
 import { useWallet } from "@/lib/wallet-context";
+import { truncateAddress } from "@/lib/stellar";
 
 /**
  * WalletMenu — desktop nav dropdown shown when a wallet is connected.
@@ -126,7 +128,7 @@ export default function WalletMenu() {
     );
   }
 
-  const shortAddress = `${wallet.slice(0, 6)}…${wallet.slice(-4)}`;
+  const shortAddress = truncateAddress(wallet);
 
   return (
     <div className="relative">
@@ -148,7 +150,9 @@ export default function WalletMenu() {
           className="h-2 w-2 rounded-full bg-emerald-500 shrink-0"
           aria-hidden="true"
         />
-        <span className="font-mono text-xs">{shortAddress}</span>
+        <span className="font-mono text-xs">
+          <TruncatedAddress address={wallet} className="font-mono text-xs" focusable={false} />
+        </span>
         {/* Chevron */}
         <svg
           className={`h-3.5 w-3.5 text-slate-400 transition-transform duration-150 ${open ? "rotate-180" : ""}`}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -208,3 +208,14 @@ export function truncateAddress(address: string, chars = 4): string {
   if (!address || address.length <= chars * 2 + 3) return address;
   return `${address.slice(0, chars + 2)}...${address.slice(-chars)}`;
 }
+
+/** Stellar account (G…) or contract (C…) StrKey — 56 chars, base32 alphabet. */
+const STELLAR_ADDRESS_RE = /^[GC][A-Z2-7]{55}$/;
+
+/**
+ * Validates a Stellar address string (account or contract).
+ * Matches the format used across profile/messages routes.
+ */
+export function isValidStellarAddress(address: string): boolean {
+  return STELLAR_ADDRESS_RE.test(address.trim());
+}


### PR DESCRIPTION
## Overview

This PR fixes three assigned Stellar Wave issues: reusable tooltips for truncated addresses, the missing Disputed dashboard filter, and Stellar token-address validation on the post-job form. It also repairs a pre-existing merge corruption in the dashboard `JobSection`/`JobCard` so those filters render correctly.

## Related Issue

Closes #608  
Closes #621  
Closes #625

## Changes

### 💬 Address Tooltips (#608)

* **[ADD]** `frontend/components/Tooltip.tsx`
  * Reusable tooltip with hover delay, viewport-aware placement, and keyboard focus support.

* **[ADD]** `frontend/components/TruncatedAddress.tsx`
  * Truncates Stellar addresses and reveals the full value via Tooltip.

* **[MODIFY]** Truncated address call sites
  * Dashboard, home, job detail, admin, compare, wallet menu, messages, transactions, meetings, and call UI now use `TruncatedAddress`.

### 🏷️ Disputed Dashboard Filter (#621)

* **[MODIFY]** `frontend/app/dashboard/page.tsx`
  * Adds `Disputed` to `STATUS_OPTIONS` so disputed jobs are filterable from the dashboard.
  * Repairs corrupted `JobSection`/`JobCard` merge (batch approve + bulk cancel) so the page parses and renders.

### ✅ Post-job Token Validation (#625)

* **[ADD]** `isValidStellarAddress()` in `frontend/lib/stellar.ts`
  * Validates `G…` / `C…` StrKey format (56 chars, base32 alphabet).

* **[MODIFY]** `frontend/app/post-job/page.tsx`
  * Inline validation on blur + submit with clear error messaging.

### 🧪 Tests

* **[ADD]** `frontend/__tests__/tooltip-truncated-address.test.tsx`
* **[MODIFY]** dashboard filter chips, post-job form/validation, and stellar helper tests

## Verification Results

```
npx vitest run __tests__/dashboard-filter-chips.test.tsx
✅ 8/8 passed (includes Disputed chip)

npx vitest run __tests__/post-job-form.test.tsx __tests__/post-job-amount-validation.test.tsx __tests__/stellar.test.ts __tests__/tooltip-truncated-address.test.tsx
✅ 23/23 passed

esbuild parse-check frontend/app/dashboard/page.tsx
✅ Done
```

| Acceptance Criteria | Status |
| --- | --- |
| Full wallet addresses shown on hover for truncated displays | ✅ `Tooltip` + `TruncatedAddress` with delay + keyboard access |
| Disputed status filter available on dashboard | ✅ Added to `STATUS_OPTIONS` / filter pills |
| Token address field rejects invalid Stellar formats | ✅ Inline feedback on blur/submit (`G…`/`C…`, 56 chars) |
| Related tests cover the new behavior | ✅ Filter, validation, tooltip, and address helper tests passing |