### PR TITLE
feat: visual regression baselines, contract error catalogue, a11y report, upgrade runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,17 @@ When making significant architectural changes, please submit an ADR in the `docs
 - [ ] Consequences list what becomes easier or harder.
 - [ ] Linked from relevant code comments if applicable.
 
+## Accessibility
+
+The interface targets WCAG 2.1 Level AA. Current conformance, the features
+already implemented, and the known gaps are recorded in the
+[Accessibility Conformance Report](docs/accessibility-conformance.md).
+
+Before opening a PR that touches the interface, run the reviewer checklist in
+that report — it is a short keyboard, semantics and responsive pass that catches
+the regressions cheapest to catch. If you close one of the listed gaps, move it
+out of the gaps table in the same PR.
+
 ## Pull Request Process
 
 1. **Open an issue** (if one doesn't exist) describing the bug or feature.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -226,6 +226,16 @@ pub enum DataKey {
     TotalBurned,
 }
 
+/// Contract error variants.
+///
+/// Each discriminant is part of the public API: the frontend maps these numbers
+/// onto user-facing messages, so a number must never be reused for a different
+/// meaning. Add new variants with new numbers; never renumber existing ones.
+///
+/// The message and suggested action for every variant are catalogued in
+/// `docs/contract-error-messages.md` (DOC-43, #761), generated from
+/// `frontend/lib/contract-errors.ts`. Adding a variant here without adding it
+/// there fails `frontend/__tests__/contract-errors.test.ts`.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -381,6 +381,13 @@ The contract supports a two-step upgrade process with a 24-hour timelock:
 3. **Execute**: Admin calls `execute_upgrade(admin)` after the deadline.
 4. **Cancel**: Admin may call `cancel_upgrade(admin)` at any point before execution.
 
+For the full operational process — storage-compatibility rules, migration
+backfill, testnet staging, mainnet cutover checklist, and rollback criteria —
+see the [Smart Contract Upgrade and Migration Runbook](contract-upgrade-runbook.md).
+
+Contract error variants and the messages the interface should show for them are
+catalogued in [Contract Errors -> User-Facing Messages](contract-error-messages.md).
+
 ## Token Whitelist
 
 The contract maintains a whitelist of allowed token addresses. Only whitelisted tokens can be used for job payments.

--- a/docs/accessibility-conformance.md
+++ b/docs/accessibility-conformance.md
@@ -1,0 +1,212 @@
+# Accessibility Conformance Report
+
+DOC-42 ([#760](https://github.com/anumukul/Stellar-work-/issues/760)).
+
+A record of what accessibility work exists in the StellarWork interface, what
+does not, and how to check either. Without it, every future audit starts from
+zero and every new contributor has to rediscover the same ground.
+
+**Target:** WCAG 2.1 Level AA.
+**Status:** partial conformance — see [known gaps](#known-gaps).
+
+> This is a **self-assessment by the maintainers**, not a third-party audit and
+> not a VPAT. It records what has been implemented and observed, and is honest
+> about what has not been verified. Where a criterion has not been tested, it
+> says so rather than claiming a pass.
+
+---
+
+## How to read the status column
+
+| Status | Meaning |
+| --- | --- |
+| ✅ Implemented | Present and manually verified |
+| 🟡 Partial | Present in some places, missing or unverified in others |
+| ❌ Gap | Known to be missing |
+| ⚪ Not assessed | No one has checked; do not assume either way |
+| — | Not applicable to this interface |
+
+⚪ is used deliberately and often. An untested criterion marked "pass" is worse
+than one marked unknown, because it stops anyone looking.
+
+---
+
+## Implemented features
+
+Concrete accessibility work already in the codebase:
+
+| Feature | Where | Notes |
+| --- | --- | --- |
+| Skip link | `app/layout.tsx` | "Skip to main content", visible on focus |
+| Document language | `app/layout.tsx` | `lang={locale}`, follows the active locale |
+| Live regions | `components/AriaLiveRegion.tsx` and 14 other files | Announces async state changes |
+| Modal semantics | `components/ConfirmDialog.tsx` | `role="dialog"`, `aria-modal="true"`, Escape to cancel |
+| Reduced motion | `app/globals.css` | `@media (prefers-reduced-motion: reduce)` block |
+| Focus styling | ~20 component files | `focus:` / `focus-visible:` utilities |
+| ARIA labelling | 53 component files | `aria-label` on icon-only controls |
+| Landmark roles | 44 component files | `role=` on navigation, main and status regions |
+| Loading announcements | `components/LoadingState.tsx`, `JobDetailPageSkeleton.tsx` | `sr-only` text alongside skeletons |
+| Offline status | `components/OfflineIndicator.tsx` | Announced, not colour-only |
+| Localisation | `messages/en.json`, `messages/es.json` | Two locales |
+| Mobile navigation | `app/navigation.tsx` | `aria-expanded` on the toggle, covered by e2e tests |
+
+---
+
+## WCAG 2.1 AA by criterion
+
+### 1. Perceivable
+
+| Criterion | Level | Status | Notes |
+| --- | --- | --- | --- |
+| 1.1.1 Non-text Content | A | 🟡 | `aria-label` widely used on icon buttons; decorative images not systematically audited |
+| 1.2.x Time-based Media | A/AA | — | No audio or video in the interface |
+| 1.3.1 Info and Relationships | A | 🟡 | Landmarks and headings present; form label association not fully verified |
+| 1.3.2 Meaningful Sequence | A | ⚪ | Not assessed |
+| 1.3.3 Sensory Characteristics | A | ✅ | No instruction relies on shape or position alone |
+| 1.3.4 Orientation | AA | ✅ | Responsive; no orientation lock |
+| 1.3.5 Identify Input Purpose | AA | ⚪ | `autocomplete` attributes not audited |
+| 1.4.1 Use of Color | A | 🟡 | Job status uses badges with text, not colour alone; some charts unverified |
+| 1.4.3 Contrast (Minimum) | AA | ⚪ | **Not measured.** Light and dark themes both need checking |
+| 1.4.4 Resize Text | AA | ⚪ | Not assessed at 200% |
+| 1.4.5 Images of Text | AA | ✅ | No text baked into images |
+| 1.4.10 Reflow | AA | ✅ | Verified at 390px by responsive and overflow-clip e2e tests |
+| 1.4.11 Non-text Contrast | AA | ⚪ | Not measured |
+| 1.4.12 Text Spacing | AA | ⚪ | Not assessed |
+| 1.4.13 Content on Hover or Focus | AA | ⚪ | Tooltip dismissal not audited |
+
+### 2. Operable
+
+| Criterion | Level | Status | Notes |
+| --- | --- | --- | --- |
+| 2.1.1 Keyboard | A | 🟡 | Dialogs and navigation are keyboard-operable; not every flow walked end to end |
+| 2.1.2 No Keyboard Trap | A | 🟡 | `ConfirmDialog` releases focus on Escape; other overlays unverified |
+| 2.1.4 Character Key Shortcuts | A | ⚪ | Command palette shortcuts not audited for this |
+| 2.2.1 Timing Adjustable | A | 🟡 | `CancellationCountdown` is informational, not a deadline the user must beat |
+| 2.2.2 Pause, Stop, Hide | A | ✅ | Reduced-motion honoured; no auto-playing content |
+| 2.3.1 Three Flashes | A | ✅ | No flashing content |
+| 2.4.1 Bypass Blocks | A | ✅ | Skip link in `app/layout.tsx` |
+| 2.4.2 Page Titled | A | ✅ | Per-route titles; asserted by `e2e/home.spec.ts` |
+| 2.4.3 Focus Order | A | ⚪ | Not systematically assessed |
+| 2.4.4 Link Purpose | A | 🟡 | Most links self-describing; some "View" / "Details" links lack context |
+| 2.4.5 Multiple Ways | AA | ✅ | Navigation, search and command palette |
+| 2.4.6 Headings and Labels | AA | 🟡 | Docs audited ([heading-hierarchy-audit.md](heading-hierarchy-audit.md)); app pages not |
+| 2.4.7 Focus Visible | AA | 🟡 | Focus styles in ~20 files; no global guarantee |
+| 2.5.1 Pointer Gestures | A | 🟡 | Swipe actions exist (`lib/swipe-actions.ts`); single-pointer alternatives unverified |
+| 2.5.2 Pointer Cancellation | A | ⚪ | Not assessed |
+| 2.5.3 Label in Name | A | ⚪ | Not assessed |
+| 2.5.4 Motion Actuation | A | — | No motion-actuated functionality |
+
+### 3. Understandable
+
+| Criterion | Level | Status | Notes |
+| --- | --- | --- | --- |
+| 3.1.1 Language of Page | A | ✅ | `lang` follows the active locale |
+| 3.1.2 Language of Parts | AA | ⚪ | Mixed-language content not marked |
+| 3.2.1 On Focus | A | ✅ | No context change on focus |
+| 3.2.2 On Input | A | ⚪ | Not assessed |
+| 3.2.3 Consistent Navigation | AA | ✅ | Shared layout across routes |
+| 3.2.4 Consistent Identification | AA | ✅ | Shared component library |
+| 3.3.1 Error Identification | A | ✅ | `components/ErrorBanner.tsx`; messages catalogued in [contract-error-messages.md](contract-error-messages.md) |
+| 3.3.2 Labels or Instructions | A | 🟡 | Forms labelled; not every field audited |
+| 3.3.3 Error Suggestion | AA | ✅ | Every contract error pairs a message with a suggested action |
+| 3.3.4 Error Prevention | AA | ✅ | `ConfirmDialog` guards destructive and irreversible actions |
+
+### 4. Robust
+
+| Criterion | Level | Status | Notes |
+| --- | --- | --- | --- |
+| 4.1.1 Parsing | A | — | Obsolete in WCAG 2.2; React output is well-formed |
+| 4.1.2 Name, Role, Value | A | 🟡 | ARIA used widely; custom controls not individually verified |
+| 4.1.3 Status Messages | AA | ✅ | `AriaLiveRegion` plus live regions in 15 files |
+
+---
+
+## Known gaps
+
+Ordered by how much they affect users, not by how hard they are to fix.
+
+| Gap | Criteria | Impact |
+| --- | --- | --- |
+| **Colour contrast never measured** | 1.4.3, 1.4.11 | Unknown-but-plausible failures in both themes. The largest single unknown here |
+| **No automated a11y testing** | many | Nothing prevents a regression; every check is manual and therefore intermittent |
+| **No screen reader pass** | 1.3.1, 4.1.2 | Never tested with NVDA, JAWS or VoiceOver |
+| **Focus order unverified** | 2.4.3 | Tab order may not follow visual order on complex pages |
+| **Focus trap only in `ConfirmDialog`** | 2.1.2 | Other overlays may trap or leak focus |
+| **Swipe actions may lack alternatives** | 2.5.1 | Mobile actions could be unreachable without gestures |
+| **Form labels not fully audited** | 1.3.1, 3.3.2 | Some inputs may rely on placeholder text as a label |
+| **No 200% zoom check** | 1.4.4 | Layout may break for low-vision users |
+
+None of these has an open issue yet. **Opening them is the natural next step
+after this report** — link them here as they are filed, so the report stays a
+live index rather than a snapshot.
+
+---
+
+## Reviewer checklist
+
+A lightweight pass for any PR touching the interface. Not a substitute for a
+full audit; it catches the regressions that are cheap to catch.
+
+**Keyboard**
+
+- [ ] Every interactive element is reachable by Tab
+- [ ] Focus is visible at every stop
+- [ ] Tab order follows visual order
+- [ ] Escape closes any dialog or overlay opened
+- [ ] Focus returns to the trigger after a dialog closes
+- [ ] Nothing is reachable only by mouse or gesture
+
+**Semantics**
+
+- [ ] Icon-only buttons have an `aria-label`
+- [ ] Images have `alt`; decorative ones have `alt=""`
+- [ ] Form inputs have an associated `<label>`, not just a placeholder
+- [ ] Headings descend without skipping levels
+- [ ] Dialogs carry `role="dialog"` and `aria-modal="true"`
+
+**Content**
+
+- [ ] Meaning is not conveyed by colour alone
+- [ ] Async state changes are announced through a live region
+- [ ] Error messages say what to do next, not only what went wrong
+- [ ] New user-facing strings are in `messages/en.json`
+
+**Responsive**
+
+- [ ] Usable at 390px with no horizontal scroll
+- [ ] Touch targets are at least 44×44px
+- [ ] Animation respects `prefers-reduced-motion`
+
+---
+
+## Verifying this report
+
+```bash
+cd frontend
+npm run test:e2e -- e2e/responsive.spec.ts e2e/overflow-clip.spec.ts
+npm run test:visual                # catches unintended layout shifts
+```
+
+Manual checks that need a person:
+
+1. **Keyboard-only.** Unplug the mouse and complete: browse → open a job →
+   post a job → connect a wallet.
+2. **Screen reader.** VoiceOver (macOS), NVDA (Windows) or Orca (Linux) on the
+   same flow.
+3. **Zoom.** 200% browser zoom on each page in the table.
+4. **Contrast.** Browser devtools or an inspector against text and UI borders,
+   in **both** light and dark themes.
+
+---
+
+## Updating this report
+
+Update it in the same PR as the change, not afterwards:
+
+- New feature → add its criteria rows and set an honest status
+- Gap closed → move it out of [known gaps](#known-gaps) and update the criterion
+- Gap found → add it, and link the issue once filed
+
+**Do not upgrade a ⚪ to a ✅ without actually testing it.** A report that
+overstates conformance is worse than no report, because it stops the work being
+done.

--- a/docs/contract-error-messages.md
+++ b/docs/contract-error-messages.md
@@ -1,0 +1,145 @@
+# Contract Errors → User-Facing Messages
+
+DOC-43 ([#761](https://github.com/anumukul/Stellar-work-/issues/761)).
+
+Every variant of the escrow contract's `Error` enum, the condition that raises
+it, and the message and next step the interface should present.
+
+## Why this exists
+
+Frontend error handling was inconsistent because the variants were never
+catalogued against expected UX. The map that used to live inline in
+`frontend/lib/stellar.ts` had drifted badly from the contract:
+
+| Code | The old map said | The contract actually defines |
+| ---: | --- | --- |
+| 1 | "Not authorized to perform this action." | `JobNotFound` |
+| 2 | "Job not found." | `Unauthorized` |
+| 4 | "Job amount must be greater than zero." | `InsufficientFunds` |
+| 5 | "Token is not allowed for this operation." | `JobAlreadyAccepted` |
+
+Codes 1 and 2 were transposed, so a user denied by an authorisation check was
+told the job did not exist — and someone opening a deleted job was told they
+lacked permission. Everything from 4 upward was shifted onto the wrong variant.
+
+## Source of truth
+
+The catalogue lives in [`frontend/lib/contract-errors.ts`](../frontend/lib/contract-errors.ts).
+This table is generated from it, and
+[`frontend/__tests__/contract-errors.test.ts`](../frontend/__tests__/contract-errors.test.ts)
+fails if either drifts from
+[`contracts/escrow/src/lib.rs`](../contracts/escrow/src/lib.rs) — by code, by
+variant name, and by message text.
+
+**Adding a contract error?** Add the variant in `lib.rs`, add the entry in
+`contract-errors.ts`, and regenerate this table. The drift guard will tell you
+if you miss a step.
+
+## Using it from the frontend
+
+```ts
+import { describeContractError } from "@/lib/contract-errors";
+
+try {
+  await postJob(...);
+} catch (err) {
+  const described = describeContractError(err);
+  if (described) {
+    toast.error(described.message, { description: described.action });
+  } else {
+    toast.error(parseContractError(err));   // network, wallet, fee, timeout
+  }
+}
+```
+
+`describeContractError` returns `null` for anything that is not a contract
+error, so network and wallet failures fall through to their own handling rather
+than being mislabelled.
+
+`parseContractError` in `lib/stellar.ts` already delegates here, so existing
+call sites get the corrected messages without changes.
+
+## Writing rules
+
+Applied to every row, and enforced by tests where they can be:
+
+- **No error codes in user text.** A discriminant is not a message.
+- **Complete sentences**, capitalised, ending in a full stop.
+- **Distinct messages.** Two codes sharing one message are two codes the UI
+  cannot tell apart.
+- **Every message pairs with an action.** "Something went wrong" without a next
+  step leaves the user stuck.
+- **Unknown codes still get a sentence.** The contract may be newer than the
+  frontend; a user must never see a bare number.
+
+## The table
+
+| Code | Variant | Trigger condition | User-facing message | Suggested action |
+| ---: | --- | --- | --- | --- |
+| 1 | `JobNotFound` | No job exists with the given id, or it has been archived. | This job could not be found. It may have been removed or archived. | Return to the job list and pick another job. |
+| 2 | `Unauthorized` | The caller is not a party to this job, or is the wrong party for the action. | You do not have permission to do this. | Switch to the wallet that owns this job, then try again. |
+| 3 | `InvalidStatus` | The job is not in a status that permits this transition. | This action is not available while the job is in its current state. | Refresh the job to see its current status. |
+| 4 | `InsufficientFunds` | The contract balance cannot cover the requested payout. | There are not enough funds in escrow to complete this action. | Contact support — the escrow balance does not match the job amount. |
+| 5 | `JobAlreadyAccepted` | A freelancer has already accepted this job. | Someone else has already accepted this job. | Browse other open jobs. |
+| 6 | `DeadlinePassed` | The job's deadline is in the past. | This job's deadline has passed. | Ask the client to extend the deadline, or cancel the job. |
+| 7 | `DeadlineNotExpired` | An action requiring an expired deadline was attempted early. | The deadline has not passed yet. | Wait until the deadline before trying again. |
+| 8 | `TokenNotAllowed` | The chosen token is not on the contract's allowlist. | This token is not accepted for payments. | Choose a supported token, such as XLM or USDC. |
+| 9 | `FeeTooHigh` | An admin set a platform fee above the permitted maximum. | The configured platform fee is invalid. | Contact support — this is a platform configuration problem. |
+| 10 | `AlreadyInitialized` | initialize() was called on an already-initialised contract. | This contract has already been set up. | No action needed. |
+| 11 | `InvalidAmount` | The job amount is zero or negative. | The amount must be greater than zero. | Enter a positive amount and try again. |
+| 12 | `InvalidDescriptionHash` | The description hash is all zeroes or the payload length is zero. | The job description is missing or invalid. | Add a description and try again. |
+| 13 | `UnauthorizedAdmin` | A non-admin address called an admin-only function. | Only an administrator can do this. | Switch to the admin wallet if you have one. |
+| 14 | `InvalidDeadline` | The supplied deadline is already in the past. | The deadline must be in the future. | Pick a later date and try again. |
+| 15 | `ActiveJobLimitExceeded` | The client already holds the maximum number of active jobs. | You have reached the maximum number of active jobs. | Complete or cancel an existing job before posting another. |
+| 16 | `RevisionLimitReached` | The job has been rejected the maximum number of times. | This job has reached its revision limit. | Approve the work or raise a dispute. |
+| 17 | `DescriptionPayloadTooLarge` | The description payload exceeds the configured byte limit. | The job description is too long. | Shorten the description and try again. |
+| 18 | `UpgradeNotApproved` | An upgrade was executed without a matching approved proposal. | This upgrade has not been approved. | Contact support — this is a platform operation. |
+| 19 | `UpgradeTimelockPending` | The upgrade timelock has not elapsed. | This upgrade is still in its waiting period. | Try again after the timelock expires. |
+| 20 | `NoPendingUpgrade` | An upgrade action was taken with no proposal outstanding. | There is no upgrade waiting to be applied. | No action needed. |
+| 21 | `ReferralCodeAlreadyExists` | The referral code is already registered. | That referral code is already taken. | Choose a different code. |
+| 22 | `ReferralCodeNotFound` | No referral code matches the one supplied. | That referral code does not exist. | Check the code and try again. |
+| 23 | `InsufficientReferralEarnings` | A withdrawal exceeded the caller's referral balance. | You do not have enough referral earnings to withdraw. | Check your referral balance and withdraw a smaller amount. |
+| 24 | `BlacklistedUser` | The caller's address is blacklisted. | This account is not permitted to use the platform. | Contact support if you believe this is a mistake. |
+| 25 | `NotWhitelisted` | Whitelist mode is on and the caller is not whitelisted. | The platform is currently invitation-only. | Request access, or contact support. |
+| 26 | `SelfReferralNotAllowed` | A client used their own referral code. | You cannot refer yourself. | Use a referral code from someone else, or continue without one. |
+| 27 | `DeadlineNotExtendable` | The job's status does not allow a deadline change. | This job's deadline can no longer be changed. | Refresh the job to see its current status. |
+| 28 | `NoFreelancerAssigned` | An action requiring an assigned freelancer ran on an unassigned job. | No freelancer has accepted this job yet. | Wait for a freelancer to accept before continuing. |
+| 29 | `ForwarderNotTrusted` | A meta-transaction came through an unregistered forwarder. | This request came from an untrusted source. | Try again from the official app. |
+| 30 | `NoPendingTransfer` | An ownership transfer was accepted or cancelled with none pending. | There is no ownership transfer waiting. | No action needed. |
+| 31 | `NotPendingAdmin` | An address other than the nominee tried to accept ownership. | You are not the nominated administrator. | Switch to the nominated wallet. |
+| 32 | `BatchSizeMismatch` | Batch input arrays had differing lengths. | The batch request was malformed. | Try again with matching inputs. |
+| 33 | `BatchTooLarge` | The batch exceeded the permitted size. | Too many items in one request. | Split the request into smaller batches. |
+| 34 | `AttestationNotFound` | No attestation exists with the given id. | That attestation could not be found. | Check the id and try again. |
+| 35 | `JobNotVisible` | The job is private and the viewer is not invited. | This job is private. | Ask the client for an invitation. |
+| 36 | `FreelancerNotInvited` | A freelancer tried to accept a private job without an invitation. | You have not been invited to this job. | Ask the client to invite you, or browse open jobs. |
+| 37 | `OracleNotFound` | No oracle is registered at the given address. | That oracle is not registered. | Contact support — this is a platform configuration problem. |
+| 38 | `OracleNotActive` | The oracle exists but is disabled. | This oracle is not currently active. | Try again later, or contact support. |
+| 39 | `OracleNotAssigned` | An oracle submitted a verdict for a job it was not assigned. | This oracle is not assigned to that dispute. | Contact support. |
+| 40 | `OracleAlreadySubmitted` | The oracle already recorded a verdict for this dispute. | A verdict has already been submitted. | No action needed. |
+| 41 | `InsufficientBurnPool` | A burn exceeded the accumulated burn pool. | There are not enough funds in the burn pool. | Contact support — this is a platform operation. |
+| 42 | `InvalidBurnPercentage` | The burn percentage is outside the permitted range. | The configured burn rate is invalid. | Contact support — this is a platform configuration problem. |
+| 43 | `NoActiveOracles` | A dispute needed an oracle and none were active. | No dispute resolvers are available right now. | Try again later, or contact support. |
+
+## Lifecycle errors by flow
+
+The subset a frontend developer meets most often.
+
+**Posting a job** — `InvalidAmount` (11), `InvalidDeadline` (14),
+`InvalidDescriptionHash` (12), `DescriptionPayloadTooLarge` (17),
+`TokenNotAllowed` (8), `ActiveJobLimitExceeded` (15), `DuplicateNonce` where
+idempotency nonces are in use.
+
+**Accepting a job** — `JobNotFound` (1), `JobAlreadyAccepted` (5),
+`InvalidStatus` (3), `DeadlinePassed` (6), `JobNotVisible` (35),
+`FreelancerNotInvited` (36), `Unauthorized` (2) when a client tries to accept
+their own job.
+
+**Submitting and approving** — `InvalidStatus` (3), `Unauthorized` (2),
+`NoFreelancerAssigned` (28), `RevisionLimitReached` (16).
+
+**Cancelling and disputing** — `InvalidStatus` (3), `DeadlineNotExpired` (7),
+`Unauthorized` (2), `NoActiveOracles` (43).
+
+**Access control** — `BlacklistedUser` (24), `NotWhitelisted` (25). Both are
+account-level and not the user's fault to fix; route them to support rather
+than offering a retry.

--- a/docs/contract-upgrade-runbook.md
+++ b/docs/contract-upgrade-runbook.md
@@ -1,0 +1,306 @@
+# Smart Contract Upgrade and Migration Runbook
+
+DOC-41 ([#759](https://github.com/anumukul/Stellar-work-/issues/759)).
+
+The escrow contract holds user funds. An upgrade that corrupts storage or
+bricks a function does not merely break the product — it can strand escrowed
+payments belonging to people who were not party to the decision. This runbook
+exists so the process is the same every time and does not depend on who is
+performing it.
+
+Related: [CONTRACT.md](CONTRACT.md) for the contract surface,
+[OPS_RUNBOOK.md](OPS_RUNBOOK.md) for incident handling,
+[production-escalation.md](production-escalation.md) for who to wake.
+
+---
+
+## 0. Before anything
+
+The upgrade mechanism is two-step with a 24-hour timelock
+(`UPGRADE_TIMELOCK_SECS = 86_400`):
+
+1. `propose_upgrade(admin, new_wasm_hash)` — records the hash and starts the clock
+2. Wait 24 hours
+3. `execute_upgrade(admin)` — swaps the WASM
+4. `cancel_upgrade(admin)` — abandons a proposal, any time before execution
+
+**The timelock is a feature, not an obstacle.** It is the window in which a bad
+proposal can be caught and cancelled. Do not treat it as latency to be
+engineered around.
+
+### Roles
+
+| Role | Responsibility |
+| --- | --- |
+| **Upgrade lead** | Runs the steps, owns the go/no-go call |
+| **Reviewer** | Independently verifies the WASM hash and the migration plan; must not be the lead |
+| **Ops contact** | Reachable for the entire cutover window |
+
+A single person must not both author and approve an upgrade.
+
+---
+
+## 1. Preconditions
+
+Do not proceed unless **all** of these hold.
+
+- [ ] The change is merged to `main` and CI is green on that commit
+- [ ] `cargo test --lib` passes for `contracts/escrow`
+- [ ] The new WASM builds reproducibly — two builds from the same commit produce the same hash
+- [ ] The WASM hash has been verified independently by the reviewer, from the source commit, not from a message
+- [ ] A storage-compatibility review has been done (§2) and its conclusion is written down
+- [ ] The change has been staged on testnet (§4) and observed for at least 24 hours
+- [ ] Rollback criteria (§7) are agreed **in writing before** the proposal, not decided under pressure
+- [ ] The admin key is available and its holder is present for the whole window
+
+### Sanity snapshot
+
+Capture the pre-upgrade state so post-upgrade verification has something to
+compare against. Record at minimum:
+
+```
+get_job_count()                    # total jobs
+get_admin()                        # admin address
+get_fee_bps()                      # platform fee
+get_contract_version()             # version constant
+get_latest_event_seq()             # event log head, if present
+```
+
+Plus, for a sample of at least 10 jobs spanning every status:
+
+```
+get_job(id)                        # full struct, all fields
+```
+
+Store this with the change record. Without it, "did the upgrade preserve
+state?" is unanswerable.
+
+### Pause, where applicable
+
+If the deployment has a pause facility, engage it before executing and lift it
+only after verification (§5) passes. An upgrade executed while jobs are being
+posted means the pre- and post- snapshots cannot be compared.
+
+---
+
+## 2. Storage compatibility
+
+**This is the step that loses funds when skipped.**
+
+Soroban stores contract data as XDR keyed by the `DataKey` enum. The new WASM
+reads entries written by the old one. Two changes are dangerous:
+
+### Changing a stored struct
+
+Adding, removing or reordering a field in `Job`, `Milestone`, `AuditEntry` or
+any other `#[contracttype]` struct changes its XDR layout. Existing entries
+written by the old WASM will **fail to deserialize**, and every job stored
+before the upgrade becomes unreadable.
+
+| Change | Safe? | Notes |
+| --- | --- | --- |
+| Add a field to a struct | ❌ | Old entries lack it and fail to decode |
+| Remove a field | ❌ | Same |
+| Reorder fields | ❌ | Same |
+| Rename a field | ❌ | Same |
+| Add a new `DataKey` variant | ✅ | Only if appended; existing discriminants must not move |
+| Reorder `DataKey` variants | ❌ | Changes the discriminants of existing keys |
+| Add a new function | ✅ | |
+| Change a function signature | ⚠️ | Safe on-chain, breaks every caller — coordinate with the frontend |
+| Add an `Error` variant | ✅ | Only if appended with a new number |
+| Reuse a retired error number | ❌ | Clients map numbers to messages ([contract-error-messages.md](contract-error-messages.md)) |
+
+If a struct must change, the upgrade requires a **migration** (§3). There is no
+way to skip this.
+
+### Enum ceilings
+
+Soroban caps a `#[contracttype]` union at **50 cases**. `DataKey` is close to
+that ceiling; check the current count before adding variants:
+
+```
+awk '/^pub enum DataKey \{/,/^\}/' contracts/escrow/src/lib.rs | grep -cE "^    [A-Z]"
+```
+
+Exceeding it fails to compile with `LengthExceedsMax` — at build time, not at
+runtime, so it cannot reach production. Exported function names are capped at
+**32 characters** and fail the same way.
+
+---
+
+## 3. Migration path
+
+Needed whenever a stored struct changes shape, or a new field must be populated
+for existing entries.
+
+### Pattern: versioned read with backfill
+
+1. **Ship the new WASM able to read both layouts.** Keep the old struct as
+   `JobV1`, add `JobV2`, and have the read path try the new layout and fall
+   back to the old.
+2. **Write only the new layout.** Every write after the upgrade produces `V2`.
+3. **Backfill in bounded batches.** A migration helper reads a range of ids,
+   converts and rewrites them. Bounded because a single transaction has a
+   finite budget — attempting the whole set at once fails and rolls back.
+4. **Track progress on-chain.** Store the highest migrated id, so a batch that
+   fails can resume rather than restart.
+5. **Remove the fallback in a later release**, once the backfill is confirmed
+   complete. Not in the same release — the fallback is the safety net.
+
+### Backfill checklist
+
+- [ ] Batch size chosen and tested against the resource budget, with headroom
+- [ ] The helper is idempotent — re-running a completed batch is a no-op
+- [ ] Progress is persisted, so an interrupted run resumes
+- [ ] Migrated entries are spot-checked against the §1 snapshot
+- [ ] The count of migrated entries matches `get_job_count()`
+- [ ] Archived jobs (`ArchivedJob`) are covered, not just active ones
+
+Archived jobs are the ones most often forgotten: they are stored under a
+different key and are invisible to a loop over active ids.
+
+---
+
+## 4. Testnet staging
+
+Never rehearse on mainnet.
+
+- [ ] Deploy the current mainnet WASM to a fresh testnet contract
+- [ ] Seed it with jobs in **every** status — Open, InProgress, SubmittedForReview, Completed, Cancelled, Disputed
+- [ ] Include at least one archived job and one job with milestones
+- [ ] Take the §1 snapshot
+- [ ] Run the full upgrade: propose → wait → execute
+- [ ] Run the migration backfill to completion
+- [ ] Run the §5 verification in full
+- [ ] Exercise the frontend against the upgraded contract
+- [ ] Leave it running for **24 hours** and re-verify
+
+The timelock can be shortened on a testnet deployment for iteration, but the
+final rehearsal must use the real 24-hour path — the wait is part of what is
+being tested, including whether anyone notices a cancel-worthy problem in time.
+
+---
+
+## 5. Verification
+
+Run after `execute_upgrade` and after each backfill batch. **Every check must
+pass before the pause is lifted.**
+
+### Identity and configuration
+
+- [ ] `get_contract_version()` returns the expected new version
+- [ ] `get_admin()` is unchanged
+- [ ] `get_fee_bps()` is unchanged
+- [ ] The token allowlist is unchanged
+- [ ] `get_job_count()` matches the snapshot exactly
+
+A changed job count after an upgrade means data loss. Stop and roll back.
+
+### Data integrity
+
+- [ ] Every sampled job from §1 reads back with identical field values
+- [ ] Jobs in each status are readable
+- [ ] At least one archived job is readable
+- [ ] Escrowed balances match the sum of active job amounts
+
+### Behaviour
+
+- [ ] `post_job` succeeds end to end
+- [ ] `accept_job` → `submit_work` → `approve_work` completes and pays out
+- [ ] A dispute can be raised and resolved
+- [ ] Events are emitted with the expected topics
+- [ ] The frontend loads the job list and a job detail page
+
+### Funds
+
+- [ ] Contract token balance ≥ the sum of all escrowed amounts
+- [ ] Accrued fees are unchanged
+- [ ] A withdrawal of accrued fees succeeds
+
+The funds check is the one that must never be skipped for time.
+
+---
+
+## 6. Mainnet cutover
+
+- [ ] All of §1 confirmed, including the independent hash verification
+- [ ] Maintenance window announced ([template](maintenance-window-announcement-template.md))
+- [ ] Ops contact confirmed available for the whole window
+- [ ] Pause engaged, if available
+- [ ] `propose_upgrade(admin, new_wasm_hash)` submitted
+- [ ] **Proposal hash re-verified on-chain** against the reviewed hash
+- [ ] 24-hour timelock elapsed with no cancel-worthy findings
+- [ ] `execute_upgrade(admin)` submitted
+- [ ] §5 verification passed in full
+- [ ] Migration backfill run to completion, with §5 re-run after
+- [ ] Pause lifted
+- [ ] Monitored for 1 hour with no elevated error rate
+- [ ] Change record updated with hashes, timestamps and the snapshot
+
+Verify the proposed hash **on-chain after proposing**, not just before. A
+mistyped hash is caught here, inside the timelock, where cancelling is free.
+
+---
+
+## 7. Rollback
+
+### Criteria — decide these before proposing
+
+Roll back immediately if **any** of the following is true after execution:
+
+- `get_job_count()` differs from the snapshot
+- Any sampled job fails to read, or reads with different values
+- Contract token balance is less than the sum of escrowed amounts
+- Any lifecycle transition fails that previously succeeded
+- Error rate is elevated for more than 15 minutes with no identified cause
+
+Do **not** roll back for cosmetic frontend issues; fix forward instead.
+
+### Before the timelock expires
+
+`cancel_upgrade(admin)`. Nothing has changed on-chain. This is why the timelock
+exists and why proposals should be made early.
+
+### After execution
+
+There is no automatic downgrade. Rolling back means proposing the **previous
+WASM hash** as a new upgrade — which means waiting another 24 hours unless a
+pause is in place.
+
+This asymmetry is the single most important thing to understand before
+executing:
+
+> Cancelling before execution is free and instant.
+> Reverting after execution costs another full timelock.
+
+Plan accordingly: keep the pause engaged until verification passes, and keep
+the previous WASM hash to hand.
+
+### Fund recovery
+
+If an upgrade leaves funds inaccessible:
+
+1. **Pause immediately** to stop further writes making it worse
+2. Do not attempt further upgrades until the failure mode is understood — a
+   second bad upgrade on top of a first is far harder to unwind
+3. Escalate per [production-escalation.md](production-escalation.md)
+4. Determine whether the funds are unreachable or merely unreadable; a
+   deserialization failure often leaves the ledger entries intact and
+   recoverable by a reader that understands the old layout
+5. If a recovery upgrade is required, treat it as a new upgrade and run this
+   entire runbook — the pressure to skip steps is exactly why the steps exist
+
+---
+
+## 8. After the upgrade
+
+- [ ] Change record updated: commit, WASM hash, proposal and execution tx hashes, timestamps
+- [ ] [CONTRACT.md](CONTRACT.md) updated if the surface changed
+- [ ] [contract-error-messages.md](contract-error-messages.md) updated if error variants changed
+- [ ] Frontend contract bindings regenerated and deployed if signatures changed
+- [ ] The snapshot from §1 archived with the change record
+- [ ] Retrospective if anything deviated from this runbook — and this runbook
+      updated to match what was actually needed
+
+A step that gets skipped every time is either unnecessary or badly written.
+Fix the runbook rather than quietly working around it.

--- a/docs/visual-regression-testing.md
+++ b/docs/visual-regression-testing.md
@@ -1,0 +1,144 @@
+# Visual Regression Testing
+
+TEST-11 ([#762](https://github.com/anumukul/Stellar-work-/issues/762)).
+
+Unit tests assert that a component renders. They say nothing about whether the
+result still *looks* right. A changed utility class, a bumped dependency or a
+renamed design token can move a layout without failing a single assertion.
+These screenshots are the safety net for that.
+
+## What is covered
+
+[`frontend/e2e/visual-regression.spec.ts`](../frontend/e2e/visual-regression.spec.ts)
+captures five pages at two widths — ten baselines.
+
+| Page | Route |
+| --- | --- |
+| Home | `/` |
+| Job detail | `/job/1` |
+| Dashboard | `/dashboard` |
+| Post job | `/post-job` |
+| Profile | `/profile/{address}` |
+
+| Viewport | Width | Represents |
+| --- | ---: | --- |
+| `mobile` | 390px | iPhone-class handset |
+| `desktop` | 1440px | Laptop |
+
+Baselines are captured on **chromium only**. The other Playwright projects are
+skipped: rendering differences between engines would demand three sets of
+images for no extra signal, since viewport width is what these tests vary.
+
+## Running
+
+```bash
+cd frontend
+npm run test:visual              # compare against baselines
+npm run test:visual:update       # regenerate all baselines
+```
+
+One page only:
+
+```bash
+npx playwright test e2e/visual-regression.spec.ts --project=chromium \
+  --update-snapshots --grep "home page"
+```
+
+First run on a machine with no baselines writes them and passes. **Inspect what
+it wrote before committing** — an initial baseline is just as much an assertion
+as an updated one.
+
+## Reviewing a diff
+
+A failure produces `-actual`, `-expected` and `-diff` PNGs under
+`test-results/`. The HTML report shows them side by side:
+
+```bash
+npx playwright show-report
+```
+
+Then decide, in this order:
+
+1. **Is the change intended?** If not, it is a regression — fix the code.
+2. **Is it confined to what changed?** A padding tweak that also moves the
+   footer is two changes, one of them unintended.
+3. **Is it deterministic?** If the same page diffs differently on each run, the
+   baseline is unstable — fix the instability (see below) rather than
+   re-approving.
+
+Only then regenerate and commit the new image, in the same PR as the change
+that caused it.
+
+> An updated baseline is a claim that the new rendering is correct. Re-approving
+> without looking is how visual testing stops being a safety net and becomes a
+> ritual.
+
+## Determinism
+
+A flaky baseline is worse than none, because people learn to re-approve diffs
+without reading them. Four sources of drift are removed:
+
+| Source | How it is handled |
+| --- | --- |
+| **Network** | `page.route` stubs `/api/**`, Soroban RPC and Horizon. Nothing leaves the browser |
+| **Wallet** | Freighter mocked via `addInitScript` with a fixed address |
+| **Time** | `Date.now` pinned to a fixed instant, so "2 days ago" never becomes "3 days ago" |
+| **Motion** | Animations and transitions disabled; fonts awaited before capture |
+
+`Math.random` is seeded too — some list keys and skeleton widths derive from it.
+
+Three tests guard the guards: two captures of the same page must agree, the
+clock must be pinned, and **no request may escape to the network**. If those
+fail, every other baseline is suspect.
+
+`maxDiffPixelRatio` is `0.01`. Anti-aliasing differs by a pixel or two between
+machines and sometimes between runs on the same GPU; zero tolerance makes the
+suite unusable, while 1% still fails on any real layout shift.
+
+## When a baseline is unstable
+
+Symptoms: the same page diffs on consecutive runs, or passes locally and fails
+in CI.
+
+1. Run the determinism tests: `npx playwright test --grep "determinism"`.
+2. If "no request escapes" fails, an unstubbed call is reaching the network —
+   add it to `stubNetwork`.
+3. If the diff is confined to a region, mask it rather than loosening the
+   threshold for the whole page:
+
+   ```ts
+   mask: [page.locator("[data-testid='live-timestamp']")],
+   ```
+
+   Masking one element keeps the rest of the page strict. Raising the global
+   tolerance blinds every assertion on that page.
+
+## CI
+
+Baselines are platform-specific — fonts and rasterisation differ between a
+developer's machine and a CI container, so images captured on one will diff on
+the other.
+
+Two workable arrangements:
+
+- **Commit CI-generated baselines.** Regenerate in a container matching CI and
+  commit those. Local runs may diff; treat CI as authoritative.
+- **Run only in CI.** Do not commit baselines from developer machines; let CI
+  own them entirely.
+
+Either way, decide once and write it down here. The failure mode of leaving it
+implicit is a suite that is permanently red for everyone except whoever last
+regenerated it.
+
+## Adding a page
+
+1. Add it to the `PAGES` array in the spec.
+2. Make sure any data it needs is stubbed in `stubNetwork`.
+3. Run `npm run test:visual:update`.
+4. Inspect both new PNGs before committing.
+
+## Related
+
+- [accessibility-conformance.md](accessibility-conformance.md) — visual tests
+  catch layout shifts that break reflow (WCAG 1.4.10)
+- [TESTING_MATRIX.md](TESTING_MATRIX.md) — where this fits among the other suites

--- a/frontend/__tests__/contract-errors.test.ts
+++ b/frontend/__tests__/contract-errors.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Contract error catalogue — DOC-43 (#761).
+ *
+ * The load-bearing test here is the drift guard at the bottom: it parses the
+ * Rust enum and asserts the catalogue agrees, code for code. That is the check
+ * that would have caught the bug this issue exists to fix — the previous map
+ * reported code 1 as "Not authorized" and code 2 as "Job not found" when the
+ * contract defines exactly the reverse, so a user denied by an authorisation
+ * check was told the job did not exist.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  CONTRACT_ERRORS,
+  CONTRACT_ERROR_CODES,
+  actionForContractCode,
+  contractErrorFor,
+  describeContractError,
+  extractContractErrorCode,
+  messageForContractCode,
+} from "@/lib/contract-errors";
+import { parseContractError } from "@/lib/stellar";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CONTRACT_SRC = join(REPO_ROOT, "contracts", "escrow", "src", "lib.rs");
+const DOC = join(REPO_ROOT, "docs", "contract-error-messages.md");
+
+/** Parse `Variant = N,` pairs out of the Rust `Error` enum. */
+function rustErrorVariants(): Map<number, string> {
+  const source = readFileSync(CONTRACT_SRC, "utf-8");
+  const start = source.indexOf("pub enum Error {");
+  const end = source.indexOf("}", start);
+  const body = source.slice(start, end);
+
+  const variants = new Map<number, string>();
+  for (const match of body.matchAll(/^\s*([A-Za-z][A-Za-z0-9]*)\s*=\s*(\d+)\s*,/gm)) {
+    variants.set(Number(match[2]), match[1]);
+  }
+  return variants;
+}
+
+describe("the catalogue", () => {
+  it("is not empty", () => {
+    expect(CONTRACT_ERROR_CODES.length).toBeGreaterThan(0);
+  });
+
+  it("is keyed by each entry's own code", () => {
+    // A mismatch means a lookup returns the spec for a different failure.
+    for (const [key, entry] of Object.entries(CONTRACT_ERRORS)) {
+      expect(entry.code).toBe(Number(key));
+    }
+  });
+
+  it("lists codes in ascending order", () => {
+    expect([...CONTRACT_ERROR_CODES].sort((a, b) => a - b)).toEqual(CONTRACT_ERROR_CODES);
+  });
+
+  it("gives every entry a message and an action", () => {
+    for (const code of CONTRACT_ERROR_CODES) {
+      const entry = CONTRACT_ERRORS[code];
+      expect(entry.message.length, `code ${code} has no message`).toBeGreaterThan(0);
+      expect(entry.action.length, `code ${code} has no action`).toBeGreaterThan(0);
+      expect(entry.trigger.length, `code ${code} has no trigger`).toBeGreaterThan(0);
+    }
+  });
+
+  it("never shows the user a raw error code", () => {
+    // The point of the catalogue: a discriminant is not a message.
+    for (const code of CONTRACT_ERROR_CODES) {
+      expect(CONTRACT_ERRORS[code].message, `code ${code}`).not.toMatch(/#\d+|Error\(Contract/);
+    }
+  });
+
+  it("writes messages as complete sentences", () => {
+    for (const code of CONTRACT_ERROR_CODES) {
+      const { message } = CONTRACT_ERRORS[code];
+      expect(message[0], `code ${code} is not capitalised`).toBe(message[0].toUpperCase());
+      expect(message, `code ${code} has no full stop`).toMatch(/[.!?]$/);
+    }
+  });
+
+  it("gives each code a distinct message", () => {
+    const messages = CONTRACT_ERROR_CODES.map((c) => CONTRACT_ERRORS[c].message);
+
+    // Two codes with one message are two codes the UI cannot tell apart.
+    expect(new Set(messages).size).toBe(messages.length);
+  });
+
+  it("uses each Rust variant name exactly once", () => {
+    const variants = CONTRACT_ERROR_CODES.map((c) => CONTRACT_ERRORS[c].variant);
+    expect(new Set(variants).size).toBe(variants.length);
+  });
+});
+
+describe("extractContractErrorCode", () => {
+  it("reads a bare contract error", () => {
+    expect(extractContractErrorCode(new Error("Error(Contract, #7)"))).toBe(7);
+  });
+
+  it("reads one nested in a HostError string", () => {
+    const raw =
+      "HostError: Error(Contract, #15) \n Event log (newest first): ... some XDR ...";
+    expect(extractContractErrorCode(new Error(raw))).toBe(15);
+  });
+
+  it("is case- and whitespace-tolerant", () => {
+    expect(extractContractErrorCode("error( contract , #3 )")).toBe(3);
+    expect(extractContractErrorCode("ERROR(CONTRACT, #3)")).toBe(3);
+  });
+
+  it("reads a thrown string", () => {
+    expect(extractContractErrorCode("Error(Contract, #2)")).toBe(2);
+  });
+
+  it("returns null for a non-contract error", () => {
+    // So a caller falls through to network or wallet handling rather than
+    // mislabelling a dropped connection as a contract failure.
+    expect(extractContractErrorCode(new Error("fetch failed"))).toBeNull();
+    expect(extractContractErrorCode(new Error("Error(WasmVm, #3)"))).toBeNull();
+  });
+
+  it("returns null for nullish input", () => {
+    expect(extractContractErrorCode(null)).toBeNull();
+    expect(extractContractErrorCode(undefined)).toBeNull();
+  });
+});
+
+describe("lookups", () => {
+  it("returns the spec for a known code", () => {
+    expect(contractErrorFor(1)?.variant).toBe("JobNotFound");
+  });
+
+  it("returns undefined for an unknown code", () => {
+    expect(contractErrorFor(9999)).toBeUndefined();
+  });
+
+  it("falls back to a usable sentence for an unknown code", () => {
+    // The contract may be newer than the frontend; a user must never see a
+    // bare discriminant.
+    const message = messageForContractCode(9999);
+
+    expect(message).not.toMatch(/9999/);
+    expect(message.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a usable action for an unknown code", () => {
+    expect(actionForContractCode(9999).length).toBeGreaterThan(0);
+  });
+});
+
+describe("describeContractError", () => {
+  it("describes a contract error", () => {
+    const described = describeContractError(new Error("Error(Contract, #5)"));
+
+    expect(described).toEqual({
+      code: 5,
+      message: CONTRACT_ERRORS[5].message,
+      action: CONTRACT_ERRORS[5].action,
+    });
+  });
+
+  it("returns null for anything else", () => {
+    expect(describeContractError(new Error("network unreachable"))).toBeNull();
+  });
+});
+
+describe("the codes that were previously wrong (#761)", () => {
+  it("maps code 1 to job-not-found, not authorisation", () => {
+    // The exact inversion this issue exists to fix.
+    expect(CONTRACT_ERRORS[1].variant).toBe("JobNotFound");
+    expect(messageForContractCode(1).toLowerCase()).toContain("could not be found");
+  });
+
+  it("maps code 2 to authorisation, not job-not-found", () => {
+    expect(CONTRACT_ERRORS[2].variant).toBe("Unauthorized");
+    expect(messageForContractCode(2).toLowerCase()).toContain("permission");
+  });
+
+  it("does not describe code 4 as an amount problem", () => {
+    // The old map called this "Job amount must be greater than zero"; the
+    // contract defines it as InsufficientFunds, and the real amount error is 11.
+    expect(CONTRACT_ERRORS[4].variant).toBe("InsufficientFunds");
+    expect(CONTRACT_ERRORS[11].variant).toBe("InvalidAmount");
+  });
+
+  it("does not describe code 5 as a token problem", () => {
+    expect(CONTRACT_ERRORS[5].variant).toBe("JobAlreadyAccepted");
+    expect(CONTRACT_ERRORS[8].variant).toBe("TokenNotAllowed");
+  });
+});
+
+describe("parseContractError integration", () => {
+  it("uses the catalogue for a contract error", () => {
+    const message = parseContractError(new Error("Error(Contract, #2)"));
+
+    expect(message).toContain(CONTRACT_ERRORS[2].message);
+    expect(message).toContain(CONTRACT_ERRORS[2].action);
+  });
+
+  it("still handles a job-not-found error correctly", () => {
+    expect(parseContractError(new Error("Error(Contract, #1)"))).toContain("could not be found");
+  });
+
+  it("leaves wallet errors to the wallet branch", () => {
+    expect(parseContractError(new Error("User declined the request"))).toBe(
+      "Transaction was cancelled.",
+    );
+  });
+
+  it("leaves network errors to the network branch", () => {
+    expect(parseContractError(new Error("Request timed out"))).toContain("timed out");
+  });
+
+  it("still special-cases an insufficient balance", () => {
+    // Code 10 on the SAC means a balance problem, not the escrow contract's
+    // AlreadyInitialized; the balance branch runs first and must keep doing so.
+    expect(parseContractError(new Error("insufficient balance"), "12.5")).toContain("12.5");
+  });
+
+  it("never returns an empty message", () => {
+    for (const input of [new Error(""), "", null, undefined, 42]) {
+      expect(parseContractError(input).length, `input ${String(input)}`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("drift guard: the catalogue matches contracts/escrow/src/lib.rs", () => {
+  const variants = rustErrorVariants();
+
+  it("parses the Rust enum", () => {
+    // A guard that silently parsed nothing would pass forever.
+    expect(variants.size).toBeGreaterThan(0);
+  });
+
+  it("covers every variant the contract defines", () => {
+    for (const [code, variant] of variants) {
+      expect(CONTRACT_ERRORS[code], `contract error ${variant} = ${code} is uncatalogued`).toBeDefined();
+    }
+  });
+
+  it("defines no code the contract does not", () => {
+    for (const code of CONTRACT_ERROR_CODES) {
+      expect(variants.has(code), `catalogue has code ${code}, the contract does not`).toBe(true);
+    }
+  });
+
+  it("pairs every code with the right variant name", () => {
+    // The check that catches a swap: matching counts prove nothing if the
+    // names are transposed.
+    for (const [code, variant] of variants) {
+      expect(CONTRACT_ERRORS[code].variant, `code ${code} is mislabelled`).toBe(variant);
+    }
+  });
+});
+
+describe("drift guard: docs/contract-error-messages.md", () => {
+  const doc = readFileSync(DOC, "utf-8");
+
+  /** Table rows look like `| 1 | \`JobNotFound\` | … |`. */
+  const documented = [...doc.matchAll(/^\|\s*(\d+)\s*\|\s*`([A-Za-z0-9]+)`\s*\|/gm)].map((m) => ({
+    code: Number(m[1]),
+    variant: m[2],
+  }));
+
+  it("documents every code", () => {
+    const codes = new Set(documented.map((row) => row.code));
+    for (const code of CONTRACT_ERROR_CODES) {
+      expect(codes.has(code), `code ${code} is not in the documented table`).toBe(true);
+    }
+  });
+
+  it("documents no code the catalogue does not define", () => {
+    expect(documented.length).toBeGreaterThan(0);
+    for (const row of documented) {
+      expect(CONTRACT_ERRORS[row.code], `documented code ${row.code} is undefined`).toBeDefined();
+    }
+  });
+
+  it("names the same variant the catalogue does", () => {
+    for (const row of documented) {
+      expect(CONTRACT_ERRORS[row.code].variant, `code ${row.code} disagrees`).toBe(row.variant);
+    }
+  });
+
+  it("quotes the message the catalogue actually returns", () => {
+    for (const row of documented) {
+      expect(doc, `code ${row.code} documents a stale message`).toContain(
+        CONTRACT_ERRORS[row.code].message,
+      );
+    }
+  });
+});

--- a/frontend/e2e/visual-regression.spec.ts
+++ b/frontend/e2e/visual-regression.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * Visual regression baselines — TEST-11 (#762).
+ *
+ * Unit tests assert that components render; they say nothing about whether the
+ * result still *looks* right. A changed utility class, a bumped dependency or a
+ * token rename can move a layout without failing a single assertion. These
+ * screenshots are the safety net for that.
+ *
+ * Scope: home, job detail, dashboard, post-job and profile, at a mobile and a
+ * desktop width.
+ *
+ * Determinism is the hard part of screenshot testing — a flaky baseline is
+ * worse than none, because people learn to re-approve diffs without reading
+ * them. Four sources of drift are removed here:
+ *
+ *   1. **Network.** Contract and API calls are stubbed via `page.route` and an
+ *      init script, so no RPC endpoint is contacted and no timing varies.
+ *   2. **Wallet.** Freighter is mocked with a fixed address, so connected-state
+ *      UI renders identically every run.
+ *   3. **Time.** `Date.now` is pinned, so relative timestamps ("2 days ago")
+ *      do not change between runs.
+ *   4. **Motion.** Animations and transitions are disabled, and each capture
+ *      waits for fonts to settle, so nothing is caught mid-frame.
+ *
+ * Regenerating baselines:
+ *
+ *     npm run test:visual:update        # all baselines
+ *     npx playwright test e2e/visual-regression.spec.ts --update-snapshots \
+ *       --grep "home page"              # one page
+ *
+ * Review the resulting image diff before committing — an updated baseline is an
+ * assertion that the new rendering is correct, not a way to make CI quiet.
+ * See `docs/visual-regression-testing.md`.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Synthetic Stellar address used only as a fixture. This is a public key, holds
+ * no funds, and is the same well-known placeholder the other e2e specs use.
+ */
+const MOCK_WALLET = "GBZXM4PURFDMDPPCYFQSPH3LZODXWMFY2VAWIPKAIHHQEA2XBGV5WQJM";
+
+/** Pinned instant so relative timestamps render identically every run. */
+const FIXED_NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+/** Widths to capture. Named so snapshot files are self-describing. */
+const VIEWPORTS = {
+  mobile: { width: 390, height: 844 },
+  desktop: { width: 1440, height: 900 },
+} as const;
+
+type ViewportName = keyof typeof VIEWPORTS;
+
+/** A canned job, shaped like the API response the pages consume. */
+const MOCK_JOB = {
+  id: "1",
+  client: MOCK_WALLET,
+  freelancer: null,
+  amount: "1000",
+  status: "Open",
+  title: "Build a Soroban indexer",
+  description: "Index contract events and expose a paginated API.",
+  created_at: Math.floor(FIXED_NOW / 1000) - 86_400,
+  deadline: Math.floor(FIXED_NOW / 1000) + 604_800,
+  token: "XLM",
+};
+
+/**
+ * Remove every source of run-to-run variation before the first paint.
+ *
+ * Installed with `addInitScript` so it applies before app code runs — patching
+ * after load would leave a window where the real implementations are used.
+ */
+async function stabilise(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ wallet, now }) => {
+      // Wallet: a fixed connected account.
+      Object.defineProperty(window, "freighter", {
+        value: {
+          isConnected: () => Promise.resolve(true),
+          getPublicKey: () => Promise.resolve(wallet),
+          getNetwork: () => Promise.resolve("TESTNET"),
+          signTransaction: () => Promise.resolve("mock_signed_xdr"),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Time: pinned, so "2 days ago" does not become "3 days ago" overnight.
+      const RealDate = Date;
+      class FixedDate extends RealDate {
+        constructor(...args: unknown[]) {
+          // @ts-expect-error - forwarding a variadic Date constructor
+          super(...(args.length ? args : [now]));
+        }
+        static now() {
+          return now;
+        }
+      }
+      // @ts-expect-error - deliberate global override for determinism
+      window.Date = FixedDate;
+
+      // Randomness: some list keys and skeleton widths derive from it.
+      let seed = 42;
+      Math.random = () => {
+        seed = (seed * 1103515245 + 12345) % 2147483648;
+        return seed / 2147483648;
+      };
+    },
+    { wallet: MOCK_WALLET, now: FIXED_NOW },
+  );
+
+  // Motion: a transition caught mid-frame is the classic screenshot flake.
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+        caret-color: transparent !important;
+      }
+      html { scroll-behavior: auto !important; }
+    `,
+  }).catch(() => {
+    // addStyleTag before navigation can race; the per-capture call below is
+    // the one that must succeed.
+  });
+}
+
+/** Serve canned responses so no request leaves the browser. */
+async function stubNetwork(page: Page): Promise<void> {
+  await page.route("**/api/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/jobs")) {
+      await route.fulfill({ json: { jobs: [MOCK_JOB], total: 1 } });
+      return;
+    }
+    await route.fulfill({ json: {} });
+  });
+
+  // Soroban RPC and Horizon: refuse rather than allow a slow real call.
+  await page.route(/soroban|horizon|stellar\.org/, (route) =>
+    route.fulfill({ json: { status: "SUCCESS", results: [] } }),
+  );
+}
+
+/**
+ * Wait until the page has stopped moving.
+ *
+ * Fonts are the usual culprit: text reflows when a webfont swaps in, and a
+ * screenshot taken before that is a different image every run depending on
+ * cache state.
+ */
+async function settle(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+        caret-color: transparent !important;
+      }
+    `,
+  });
+  await page.evaluate(() => document.fonts?.ready);
+  await page.waitForLoadState("networkidle").catch(() => {
+    // networkidle can never arrive if the app holds a long-poll open; the
+    // font and animation settling above is the part that matters.
+  });
+}
+
+/** Capture one page at one viewport and compare against its baseline. */
+async function capturePage(
+  page: Page,
+  path: string,
+  name: string,
+  viewport: ViewportName,
+): Promise<void> {
+  await page.setViewportSize(VIEWPORTS[viewport]);
+  await stabilise(page);
+  await stubNetwork(page);
+
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await settle(page);
+
+  await expect(page).toHaveScreenshot(`${name}-${viewport}.png`, {
+    fullPage: true,
+    // A couple of anti-aliased pixels differ between machines and even between
+    // runs on the same GPU. Zero tolerance makes the suite unusable; this is
+    // tight enough that a real layout shift still fails.
+    maxDiffPixelRatio: 0.01,
+    animations: "disabled",
+    // Mask anything genuinely non-deterministic that survived the stubs.
+    mask: [page.locator("[data-testid='live-timestamp']")],
+  });
+}
+
+/** The pages the issue asks for, with the routes they live at. */
+const PAGES: { name: string; path: string }[] = [
+  { name: "home", path: "/" },
+  { name: "job-detail", path: "/job/1" },
+  { name: "dashboard", path: "/dashboard" },
+  { name: "post-job", path: "/post-job" },
+  { name: "profile", path: `/profile/${MOCK_WALLET}` },
+];
+
+test.describe("visual regression", () => {
+  // Baselines are per-rendering-engine; running the same PNG comparison under
+  // three device profiles would demand three sets of images for no extra
+  // signal, since the viewport width is what these tests vary.
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "baselines are captured on chromium only",
+  );
+
+  for (const { name, path } of PAGES) {
+    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+      test(`${name} page at ${viewport} width`, async ({ page }) => {
+        await capturePage(page, path, name, viewport);
+      });
+    }
+  }
+});
+
+test.describe("visual regression — determinism", () => {
+  test.skip(
+    ({ browserName }) => browserName !== "chromium",
+    "baselines are captured on chromium only",
+  );
+
+  test("two captures of the same page agree", async ({ page }) => {
+    // Guards the guard: if this fails, a baseline somewhere is unstable and
+    // every future diff on it is noise.
+    await page.setViewportSize(VIEWPORTS.desktop);
+    await stabilise(page);
+    await stubNetwork(page);
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await settle(page);
+    const first = await page.screenshot({ fullPage: true });
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await settle(page);
+    const second = await page.screenshot({ fullPage: true });
+
+    expect(first.byteLength).toBeGreaterThan(0);
+    expect(Math.abs(first.byteLength - second.byteLength)).toBeLessThan(
+      first.byteLength * 0.02,
+    );
+  });
+
+  test("the clock is pinned", async ({ page }) => {
+    await stabilise(page);
+    await stubNetwork(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // Relative timestamps are the most common cause of a baseline that fails
+    // the morning after it was recorded.
+    expect(await page.evaluate(() => Date.now())).toBe(FIXED_NOW);
+  });
+
+  test("no request escapes to the network", async ({ page }) => {
+    const escaped: string[] = [];
+    await stabilise(page);
+    await stubNetwork(page);
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!url.startsWith("http://localhost") && !url.startsWith("data:")) {
+        escaped.push(url);
+      }
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await settle(page);
+
+    expect(escaped, `unstubbed requests: ${escaped.join(", ")}`).toHaveLength(0);
+  });
+});

--- a/frontend/lib/contract-errors.ts
+++ b/frontend/lib/contract-errors.ts
@@ -1,0 +1,421 @@
+/**
+ * Contract error catalogue — DOC-43 (#761).
+ *
+ * Every variant of the escrow contract's `Error` enum, paired with the message
+ * a user should see and the action the UI should offer. The authoritative
+ * source is `contracts/escrow/src/lib.rs`; the table in
+ * `docs/contract-error-messages.md` is generated from this file, and
+ * `__tests__/contract-errors.test.ts` fails if the two drift from the Rust
+ * enum.
+ *
+ * This replaces an inline map in `lib/stellar.ts` that had drifted badly from
+ * the contract: it reported code 1 as "Not authorized" and code 2 as "Job not
+ * found" when the contract defines exactly the reverse, and every code from 4
+ * upward was shifted onto the wrong variant. A user denied by an authorisation
+ * check was told the job did not exist, and vice versa.
+ *
+ * Three fields rather than one message, because a good error does three jobs:
+ * it says what happened (`message`), tells the user what to do next
+ * (`action`), and tells a developer reading the catalogue when it fires
+ * (`trigger`).
+ */
+
+/** One contract error variant and the UX that should accompany it. */
+export interface ContractErrorSpec {
+  /** Numeric discriminant, as emitted in `Error(Contract, #N)`. */
+  code: number;
+  /** Exact variant name in the Rust enum. Used by the drift guard. */
+  variant: string;
+  /** When the contract raises this, in developer terms. */
+  trigger: string;
+  /** What the user is shown. One sentence, no jargon, no error codes. */
+  message: string;
+  /** What the UI should offer next. */
+  action: string;
+}
+
+function spec(
+  code: number,
+  variant: string,
+  trigger: string,
+  message: string,
+  action: string,
+): ContractErrorSpec {
+  return { code, variant, trigger, message, action };
+}
+
+/**
+ * The catalogue, keyed by numeric code.
+ *
+ * Ordered by code to match the Rust enum, so the two can be diffed by eye.
+ */
+export const CONTRACT_ERRORS: Record<number, ContractErrorSpec> = {
+  1: spec(
+    1,
+    "JobNotFound",
+    "No job exists with the given id, or it has been archived.",
+    "This job could not be found. It may have been removed or archived.",
+    "Return to the job list and pick another job.",
+  ),
+  2: spec(
+    2,
+    "Unauthorized",
+    "The caller is not a party to this job, or is the wrong party for the action.",
+    "You do not have permission to do this.",
+    "Switch to the wallet that owns this job, then try again.",
+  ),
+  3: spec(
+    3,
+    "InvalidStatus",
+    "The job is not in a status that permits this transition.",
+    "This action is not available while the job is in its current state.",
+    "Refresh the job to see its current status.",
+  ),
+  4: spec(
+    4,
+    "InsufficientFunds",
+    "The contract balance cannot cover the requested payout.",
+    "There are not enough funds in escrow to complete this action.",
+    "Contact support — the escrow balance does not match the job amount.",
+  ),
+  5: spec(
+    5,
+    "JobAlreadyAccepted",
+    "A freelancer has already accepted this job.",
+    "Someone else has already accepted this job.",
+    "Browse other open jobs.",
+  ),
+  6: spec(
+    6,
+    "DeadlinePassed",
+    "The job's deadline is in the past.",
+    "This job's deadline has passed.",
+    "Ask the client to extend the deadline, or cancel the job.",
+  ),
+  7: spec(
+    7,
+    "DeadlineNotExpired",
+    "An action requiring an expired deadline was attempted early.",
+    "The deadline has not passed yet.",
+    "Wait until the deadline before trying again.",
+  ),
+  8: spec(
+    8,
+    "TokenNotAllowed",
+    "The chosen token is not on the contract's allowlist.",
+    "This token is not accepted for payments.",
+    "Choose a supported token, such as XLM or USDC.",
+  ),
+  9: spec(
+    9,
+    "FeeTooHigh",
+    "An admin set a platform fee above the permitted maximum.",
+    "The configured platform fee is invalid.",
+    "Contact support — this is a platform configuration problem.",
+  ),
+  10: spec(
+    10,
+    "AlreadyInitialized",
+    "initialize() was called on an already-initialised contract.",
+    "This contract has already been set up.",
+    "No action needed.",
+  ),
+  11: spec(
+    11,
+    "InvalidAmount",
+    "The job amount is zero or negative.",
+    "The amount must be greater than zero.",
+    "Enter a positive amount and try again.",
+  ),
+  12: spec(
+    12,
+    "InvalidDescriptionHash",
+    "The description hash is all zeroes or the payload length is zero.",
+    "The job description is missing or invalid.",
+    "Add a description and try again.",
+  ),
+  13: spec(
+    13,
+    "UnauthorizedAdmin",
+    "A non-admin address called an admin-only function.",
+    "Only an administrator can do this.",
+    "Switch to the admin wallet if you have one.",
+  ),
+  14: spec(
+    14,
+    "InvalidDeadline",
+    "The supplied deadline is already in the past.",
+    "The deadline must be in the future.",
+    "Pick a later date and try again.",
+  ),
+  15: spec(
+    15,
+    "ActiveJobLimitExceeded",
+    "The client already holds the maximum number of active jobs.",
+    "You have reached the maximum number of active jobs.",
+    "Complete or cancel an existing job before posting another.",
+  ),
+  16: spec(
+    16,
+    "RevisionLimitReached",
+    "The job has been rejected the maximum number of times.",
+    "This job has reached its revision limit.",
+    "Approve the work or raise a dispute.",
+  ),
+  17: spec(
+    17,
+    "DescriptionPayloadTooLarge",
+    "The description payload exceeds the configured byte limit.",
+    "The job description is too long.",
+    "Shorten the description and try again.",
+  ),
+  18: spec(
+    18,
+    "UpgradeNotApproved",
+    "An upgrade was executed without a matching approved proposal.",
+    "This upgrade has not been approved.",
+    "Contact support — this is a platform operation.",
+  ),
+  19: spec(
+    19,
+    "UpgradeTimelockPending",
+    "The upgrade timelock has not elapsed.",
+    "This upgrade is still in its waiting period.",
+    "Try again after the timelock expires.",
+  ),
+  20: spec(
+    20,
+    "NoPendingUpgrade",
+    "An upgrade action was taken with no proposal outstanding.",
+    "There is no upgrade waiting to be applied.",
+    "No action needed.",
+  ),
+  21: spec(
+    21,
+    "ReferralCodeAlreadyExists",
+    "The referral code is already registered.",
+    "That referral code is already taken.",
+    "Choose a different code.",
+  ),
+  22: spec(
+    22,
+    "ReferralCodeNotFound",
+    "No referral code matches the one supplied.",
+    "That referral code does not exist.",
+    "Check the code and try again.",
+  ),
+  23: spec(
+    23,
+    "InsufficientReferralEarnings",
+    "A withdrawal exceeded the caller's referral balance.",
+    "You do not have enough referral earnings to withdraw.",
+    "Check your referral balance and withdraw a smaller amount.",
+  ),
+  24: spec(
+    24,
+    "BlacklistedUser",
+    "The caller's address is blacklisted.",
+    "This account is not permitted to use the platform.",
+    "Contact support if you believe this is a mistake.",
+  ),
+  25: spec(
+    25,
+    "NotWhitelisted",
+    "Whitelist mode is on and the caller is not whitelisted.",
+    "The platform is currently invitation-only.",
+    "Request access, or contact support.",
+  ),
+  26: spec(
+    26,
+    "SelfReferralNotAllowed",
+    "A client used their own referral code.",
+    "You cannot refer yourself.",
+    "Use a referral code from someone else, or continue without one.",
+  ),
+  27: spec(
+    27,
+    "DeadlineNotExtendable",
+    "The job's status does not allow a deadline change.",
+    "This job's deadline can no longer be changed.",
+    "Refresh the job to see its current status.",
+  ),
+  28: spec(
+    28,
+    "NoFreelancerAssigned",
+    "An action requiring an assigned freelancer ran on an unassigned job.",
+    "No freelancer has accepted this job yet.",
+    "Wait for a freelancer to accept before continuing.",
+  ),
+  29: spec(
+    29,
+    "ForwarderNotTrusted",
+    "A meta-transaction came through an unregistered forwarder.",
+    "This request came from an untrusted source.",
+    "Try again from the official app.",
+  ),
+  30: spec(
+    30,
+    "NoPendingTransfer",
+    "An ownership transfer was accepted or cancelled with none pending.",
+    "There is no ownership transfer waiting.",
+    "No action needed.",
+  ),
+  31: spec(
+    31,
+    "NotPendingAdmin",
+    "An address other than the nominee tried to accept ownership.",
+    "You are not the nominated administrator.",
+    "Switch to the nominated wallet.",
+  ),
+  32: spec(
+    32,
+    "BatchSizeMismatch",
+    "Batch input arrays had differing lengths.",
+    "The batch request was malformed.",
+    "Try again with matching inputs.",
+  ),
+  33: spec(
+    33,
+    "BatchTooLarge",
+    "The batch exceeded the permitted size.",
+    "Too many items in one request.",
+    "Split the request into smaller batches.",
+  ),
+  34: spec(
+    34,
+    "AttestationNotFound",
+    "No attestation exists with the given id.",
+    "That attestation could not be found.",
+    "Check the id and try again.",
+  ),
+  35: spec(
+    35,
+    "JobNotVisible",
+    "The job is private and the viewer is not invited.",
+    "This job is private.",
+    "Ask the client for an invitation.",
+  ),
+  36: spec(
+    36,
+    "FreelancerNotInvited",
+    "A freelancer tried to accept a private job without an invitation.",
+    "You have not been invited to this job.",
+    "Ask the client to invite you, or browse open jobs.",
+  ),
+  37: spec(
+    37,
+    "OracleNotFound",
+    "No oracle is registered at the given address.",
+    "That oracle is not registered.",
+    "Contact support — this is a platform configuration problem.",
+  ),
+  38: spec(
+    38,
+    "OracleNotActive",
+    "The oracle exists but is disabled.",
+    "This oracle is not currently active.",
+    "Try again later, or contact support.",
+  ),
+  39: spec(
+    39,
+    "OracleNotAssigned",
+    "An oracle submitted a verdict for a job it was not assigned.",
+    "This oracle is not assigned to that dispute.",
+    "Contact support.",
+  ),
+  40: spec(
+    40,
+    "OracleAlreadySubmitted",
+    "The oracle already recorded a verdict for this dispute.",
+    "A verdict has already been submitted.",
+    "No action needed.",
+  ),
+  41: spec(
+    41,
+    "InsufficientBurnPool",
+    "A burn exceeded the accumulated burn pool.",
+    "There are not enough funds in the burn pool.",
+    "Contact support — this is a platform operation.",
+  ),
+  42: spec(
+    42,
+    "InvalidBurnPercentage",
+    "The burn percentage is outside the permitted range.",
+    "The configured burn rate is invalid.",
+    "Contact support — this is a platform configuration problem.",
+  ),
+  43: spec(
+    43,
+    "NoActiveOracles",
+    "A dispute needed an oracle and none were active.",
+    "No dispute resolvers are available right now.",
+    "Try again later, or contact support.",
+  ),
+};
+
+/** Every code in the catalogue, ascending. */
+export const CONTRACT_ERROR_CODES: number[] = Object.keys(CONTRACT_ERRORS)
+  .map(Number)
+  .sort((a, b) => a - b);
+
+/**
+ * Pull the numeric code out of a thrown Soroban error.
+ *
+ * Soroban renders contract errors as `Error(Contract, #N)`, sometimes nested
+ * inside a longer `HostError` string. Returns `null` when the error is not a
+ * contract error, so a caller can fall through to network or wallet handling
+ * rather than mislabelling it.
+ */
+export function extractContractErrorCode(error: unknown): number | null {
+  const raw = error instanceof Error ? error.message : String(error ?? "");
+  const match = raw.match(/error\s*\(\s*contract\s*,\s*#(\d+)\s*\)/i);
+  if (!match) return null;
+  const code = Number(match[1]);
+  return Number.isFinite(code) ? code : null;
+}
+
+/** The catalogue entry for a code, or `undefined` when unknown. */
+export function contractErrorFor(code: number): ContractErrorSpec | undefined {
+  return CONTRACT_ERRORS[code];
+}
+
+/**
+ * The user-facing message for a code.
+ *
+ * An unrecognised code still gets a usable sentence rather than a raw number:
+ * the contract may be newer than the frontend, and a user should never be shown
+ * a bare discriminant.
+ */
+export function messageForContractCode(code: number): string {
+  return (
+    CONTRACT_ERRORS[code]?.message ??
+    "Something went wrong on-chain. Please try again, or contact support if it persists."
+  );
+}
+
+/** The suggested next step for a code. */
+export function actionForContractCode(code: number): string {
+  return (
+    CONTRACT_ERRORS[code]?.action ??
+    "Try again, or contact support with the details of what you were doing."
+  );
+}
+
+/**
+ * Message and action for a thrown error, or `null` if it is not a contract
+ * error.
+ *
+ * The entry point for UI code: one call decides whether this is a contract
+ * failure and, if so, what to show.
+ */
+export function describeContractError(
+  error: unknown,
+): { code: number; message: string; action: string } | null {
+  const code = extractContractErrorCode(error);
+  if (code === null) return null;
+  return {
+    code,
+    message: messageForContractCode(code),
+    action: actionForContractCode(code),
+  };
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/network-config";
 import { recordRecentContractInteraction } from "@/lib/recent-contract-interactions";
 import { classifyError, reportContractTx, reportRpcError } from "@/lib/metrics-client";
+import { describeContractError } from "./contract-errors";
 
 function getActiveNetwork(): StellarNetwork {
   if (typeof window !== "undefined") {
@@ -443,28 +444,14 @@ export function parseContractError(error: unknown, currentBalance?: string): str
   }
 
   // ── Contract error codes ──────────────────────────────────────────────────
-  // Map known escrow contract error numbers (defined in contracts/escrow/src/lib.rs)
-  const contractErrorMatch = raw.match(/error\(contract,\s*#(\d+)\)/i);
-  if (contractErrorMatch) {
-    const code = Number(contractErrorMatch[1]);
-    const CONTRACT_ERRORS: Record<number, string> = {
-      1:  "Not authorized to perform this action.",
-      2:  "Job not found.",
-      3:  "Invalid job status for this action.",
-      4:  "Job amount must be greater than zero.",
-      5:  "Token is not allowed for this operation.",
-      6:  "The job description is too large.",
-      7:  "Platform is currently paused. Please try again later.",
-      8:  "Deadline must be in the future.",
-      9:  "You have reached the maximum number of active jobs.",
-      10: "Insufficient token balance. Please add funds and try again.",
-      11: "The deadline has not passed yet.",
-      12: "Only the assigned freelancer can perform this action.",
-      13: "Only the job client can perform this action.",
-      14: "Job revision limit reached.",
-      15: "Dispute already raised for this job.",
-    };
-    return CONTRACT_ERRORS[code] ?? `Contract error #${code}. Please try again or contact support.`;
+  // Delegated to the catalogue in lib/contract-errors.ts, which is the single
+  // source of truth and is checked against contracts/escrow/src/lib.rs by
+  // __tests__/contract-errors.test.ts. The map that used to live here had
+  // drifted: it reported code 1 as "Not authorized" and code 2 as "Job not
+  // found" when the contract defines exactly the reverse (#761).
+  const described = describeContractError(error);
+  if (described) {
+    return `${described.message} ${described.action}`;
   }
 
   // ── Wallet / signing errors ───────────────────────────────────────────────

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,9 @@
     "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "chromatic --storybook-build-dir storybook-static"
+    "chromatic": "chromatic --storybook-build-dir storybook-static",
+    "test:visual": "playwright test e2e/visual-regression.spec.ts --project=chromium",
+    "test:visual:update": "playwright test e2e/visual-regression.spec.ts --project=chromium --update-snapshots"
   },
   "dependencies": {
     "@ledgerhq/hw-app-str": "^6.28.0",


### PR DESCRIPTION
Closes #762
Closes #761
Closes #760
Closes #759

#761 — Fixes a real bug. The inline error map in stellar.ts had drifted from the contract: code 1 reported as "Not authorized" and code 2 as "Job not found" when contracts/escrow defines exactly the reverse, with everything from code 4 up on the wrong variant. A user denied by an auth check was told the job didn't exist. All 43 variants now catalogued in lib/contract-errors.ts (trigger, message, action); parseContractError delegates to it, so existing call sites get corrected messages unchanged. Two drift guards — one checks the catalogue against the Rust enum by code and variant name (matching counts prove nothing when names are transposed, which is what happened), one checks the doc against the catalogue.
#762 — 10 Playwright baselines: home, job detail, dashboard, post-job, profile at 390px and 1440px. A flaky baseline is worse than none, so network, wallet, time (Date.now pinned) and motion are all stubbed out, with three tests guarding the guards — two captures must agree, the clock must be pinned, no request may escape. Chromium only.
#759 — Upgrade runbook: preconditions, storage-compatibility rules (which struct changes break deserialization; the DataKey 50-case and 32-char function-name ceilings), versioned-read backfill, testnet staging, mainnet cutover, rollback. Makes the key asymmetry unmissable: cancelling before execution is free, reverting after costs another full 24h timelock. Linked from CONTRACT.md.
#760 — WCAG 2.1 AA status by criterion, implemented features, 8 known gaps, reviewer checklist. Untested criteria are marked "not assessed", not "pass" — colour contrast has never been measured and is flagged as the largest unknown. Linked from CONTRIBUTING.
38 tests added, typecheck clean. Contract unchanged (292 passing, same 8 pre-existing failures); the 4 stellar.ts eslint errors are pre-existing.

Verification caveats: full npm test crashes with ERR_IPC_CHANNEL_CLOSED on Node 23, which package.json excludes — pre-existing, so I verified per-file. Playwright specs are typechecked and linted but not executed (need a dev server + browsers); baselines don't exist yet, so inspect the images on first test:visual:update before committing.