### PR TITLE
feat: add environment variable validation at build time

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -14,6 +14,23 @@ Create `frontend/.env.local` from `frontend/.env.example` for local development.
 | `NEXT_PUBLIC_NATIVE_TOKEN` | No | Empty string | `frontend/app/post-job/page.tsx` | Optional token contract address used to prefill the Post Job form. Users can still type a token address manually. |
 | `NEXT_PUBLIC_ADMIN_ADDRESS` | No | Empty string | `frontend/app/navigation.tsx`, `frontend/app/admin/page.tsx` | Admin Stellar address. When set, the Admin link is shown only to that connected wallet. |
 
+### Build-Time Validation (#645)
+
+`npm run build` runs `npm run prebuild` first, which invokes
+`frontend/scripts/validate-env.mjs`. It checks the same required variables as
+`frontend/lib/config.ts`'s `validateConfig()`, but fails the build (exit code
+1) rather than surfacing a runtime error to a user in the browser:
+
+- Missing `NEXT_PUBLIC_CONTRACT_ID` (and no per-network fallback set) — error
+- `NEXT_PUBLIC_CONTRACT_ID` that isn't a well-formed Soroban contract ID
+  (`C` + 55 base32 characters) — error
+- `NEXT_PUBLIC_NETWORK=mainnet` combined with a `NEXT_PUBLIC_SOROBAN_RPC`
+  that still points at a testnet endpoint — error
+- Unrecognized `NEXT_PUBLIC_NETWORK` value, missing `NEXT_PUBLIC_NATIVE_TOKEN`,
+  missing `NEXT_PUBLIC_ADMIN_ADDRESS` — warning only, build continues
+
+Run it standalone at any time with `npm run validate-env` from `frontend/`.
+
 ## Local Development
 ## Environment Overview
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "validate-env": "node scripts/validate-env.mjs",
+    "prebuild": "npm run validate-env",
     "build": "next build",
     "start": "next start",
     "analyze": "ANALYZE=true npm run build",

--- a/frontend/scripts/validate-env.mjs
+++ b/frontend/scripts/validate-env.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Build-time environment variable validation (#645).
+//
+// Mirrors the required/optional checks in lib/config.ts's validateConfig(),
+// but runs as a plain Node script so it can fail the build *before* `next
+// build` starts — catching a missing NEXT_PUBLIC_CONTRACT_ID at deploy time
+// instead of as a runtime error a user hits in the browser.
+//
+// Wired as the "prebuild" script in package.json, so `npm run build` runs
+// this automatically. Can also be run standalone: `npm run validate-env`.
+
+const errors = [];
+const warnings = [];
+
+const contractId =
+  process.env.NEXT_PUBLIC_CONTRACT_ID_TESTNET ??
+  process.env.NEXT_PUBLIC_CONTRACT_ID_FUTURENET ??
+  process.env.NEXT_PUBLIC_CONTRACT_ID_MAINNET ??
+  process.env.NEXT_PUBLIC_CONTRACT_ID ??
+  "";
+
+if (!contractId) {
+  errors.push(
+    "NEXT_PUBLIC_CONTRACT_ID is required (or one of the per-network " +
+      "variants: NEXT_PUBLIC_CONTRACT_ID_TESTNET / _FUTURENET / _MAINNET). " +
+      "Set it to the deployed escrow contract ID.",
+  );
+} else if (!/^C[A-Z2-7]{55}$/.test(contractId)) {
+  // Soroban contract IDs are StrKey-encoded: 'C' prefix + 55 base32 chars.
+  errors.push(
+    `NEXT_PUBLIC_CONTRACT_ID ("${contractId}") does not look like a valid ` +
+      "Soroban contract ID (expected 'C' followed by 55 base32 characters).",
+  );
+}
+
+const networkRaw = process.env.NEXT_PUBLIC_NETWORK ?? "";
+if (networkRaw && !["mainnet", "testnet", "futurenet"].includes(networkRaw)) {
+  warnings.push(
+    `NEXT_PUBLIC_NETWORK has unrecognized value "${networkRaw}" ` +
+      '(expected "mainnet", "testnet", or "futurenet"); the app will default to "testnet".',
+  );
+}
+
+const sorobanRpc = process.env.NEXT_PUBLIC_SOROBAN_RPC ?? "";
+if (networkRaw === "mainnet" && sorobanRpc.includes("testnet")) {
+  errors.push(
+    "NEXT_PUBLIC_NETWORK is \"mainnet\" but NEXT_PUBLIC_SOROBAN_RPC points " +
+      "to a testnet endpoint. Refusing to build a mainnet deployment " +
+      "wired to testnet RPC.",
+  );
+}
+
+if (!process.env.NEXT_PUBLIC_NATIVE_TOKEN) {
+  warnings.push(
+    "NEXT_PUBLIC_NATIVE_TOKEN is not set. The post-job form will require manual token address entry.",
+  );
+}
+if (!process.env.NEXT_PUBLIC_ADMIN_ADDRESS) {
+  warnings.push(
+    "NEXT_PUBLIC_ADMIN_ADDRESS is not set. Admin panel will be disabled for safety.",
+  );
+}
+
+for (const warning of warnings) {
+  console.warn(`::warning title=Env validation::${warning}`);
+}
+
+if (errors.length > 0) {
+  console.error("\nEnvironment validation failed:\n");
+  for (const error of errors) {
+    console.error(`  ✗ ${error}`);
+  }
+  console.error(
+    "\nSee frontend/.env.example for the full list of variables, or docs/environments.md.\n",
+  );
+  process.exit(1);
+}
+
+console.log(`Env validation passed (${warnings.length} warning(s)).`);


### PR DESCRIPTION
## Summary

Adds `frontend/scripts/validate-env.mjs`, wired as the `prebuild` npm script so `npm run build` fails fast with a clear message instead of shipping a build that only fails at runtime in a user's browser.

Checks:
- Missing `NEXT_PUBLIC_CONTRACT_ID` (or its per-network `_TESTNET`/`_FUTURENET`/`_MAINNET` variants) → **error**
- Malformed contract ID (not `C` + 55 base32 characters) → **error**
- `NEXT_PUBLIC_NETWORK=mainnet` paired with a `NEXT_PUBLIC_SOROBAN_RPC` that still points at a testnet endpoint → **error**
- Unrecognized network value, missing native token, missing admin address → **warning only**, build still proceeds

Mirrors the checks already implemented in `frontend/lib/config.ts`'s `validateConfig()`, but runs standalone ahead of `next build` (via npm's automatic `prebuild` hook) rather than only at runtime. Also runnable on its own via `npm run validate-env`.

Documented in `docs/environments.md`.

Closes #645
Closes #730
Closes #587
Closes #814