### PR TITLE
feat: Add RSS feed for open job listings

### DIFF
--- a/frontend/__tests__/feed-route.test.ts
+++ b/frontend/__tests__/feed-route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../app/feed.xml/route";
+import { getJobCount, getJob, getDescriptionCid } from "@/lib/contract";
+import { fetchFromIpfs } from "@/lib/ipfs-service";
+import type { Job } from "@/lib/types";
+
+vi.mock("@/lib/contract", () => ({
+  getJobCount: vi.fn(),
+  getJob: vi.fn(),
+  getDescriptionCid: vi.fn(),
+}));
+
+vi.mock("@/lib/ipfs-service", () => ({
+  fetchFromIpfs: vi.fn(),
+}));
+
+const mockJob: Job = {
+  client: "GA123456789012345678901234567890123456789012345678901234",
+  freelancer: null,
+  amount: "100000000",
+  description_hash: "abcd",
+  description_payload_len: 4,
+  deadline: "1672531200", // 2023-01-01
+  status: "Open",
+  token_address: "token",
+  title: "Test Job",
+  category: "dev",
+  created_at: "1672530000",
+};
+
+describe("RSS Feed Route (/feed.xml)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return valid RSS for empty feed case", async () => {
+    vi.mocked(getJobCount).mockResolvedValue(0);
+
+    const request = new Request("http://localhost:3000/feed.xml");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/rss+xml");
+    
+    const text = await response.text();
+    expect(text).toContain('<?xml version="1.0" encoding="UTF-8" ?>');
+    expect(text).toContain('<rss version="2.0"');
+    expect(text).toContain('<title>StellarWork Open Jobs</title>');
+    expect(text).not.toContain('<item>');
+  });
+
+  it("should include open jobs with titles, descriptions, and correct fields", async () => {
+    vi.mocked(getJobCount).mockResolvedValue(2);
+    vi.mocked(getJob).mockImplementation(async (id: string) => {
+      if (id === "2") return { ...mockJob, title: "Open Job 2", status: "Open" };
+      if (id === "1") return { ...mockJob, title: "Closed Job", status: "Completed" };
+      return null;
+    });
+    vi.mocked(getDescriptionCid).mockResolvedValue("cid123");
+    vi.mocked(fetchFromIpfs).mockResolvedValue("Test Description 123");
+
+    const request = new Request("http://localhost:3000/feed.xml");
+    const response = await GET(request);
+    
+    const text = await response.text();
+
+    expect(text).toContain("<item>");
+    expect(text).toContain("<title>Open Job 2</title>");
+    expect(text).toContain("Test Description 123");
+    expect(text).toContain("Amount: 10 XLM"); // 100000000 stroops = 10 XLM
+    expect(text).toContain("Client: GA1234...1234");
+    expect(text).toContain("<link>http://localhost:3000/job/2</link>");
+    expect(text).not.toContain("Closed Job");
+  });
+
+  it("should fallback to unavailable description if IPFS fails", async () => {
+    vi.mocked(getJobCount).mockResolvedValue(1);
+    vi.mocked(getJob).mockResolvedValue({ ...mockJob, status: "Open" });
+    vi.mocked(getDescriptionCid).mockResolvedValue("cid123");
+    vi.mocked(fetchFromIpfs).mockRejectedValue(new Error("IPFS failed"));
+
+    const request = new Request("http://localhost:3000/feed.xml");
+    const response = await GET(request);
+    
+    const text = await response.text();
+    expect(text).toContain("Description unavailable");
+  });
+});

--- a/frontend/app/feed.xml/route.ts
+++ b/frontend/app/feed.xml/route.ts
@@ -1,0 +1,113 @@
+import { getJobCount, getJob, getDescriptionCid } from "@/lib/contract";
+import { fetchFromIpfs } from "@/lib/ipfs-service";
+import { toXlm } from "@/lib/format";
+import type { Job } from "@/lib/types";
+
+export const revalidate = 300; // 5 minutes cache TTL
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || url.origin;
+
+  let count = 0;
+  try {
+    count = await getJobCount();
+  } catch (e) {
+    count = 0;
+  }
+
+  const MAX_JOBS = 50;
+  const startId = Math.max(1, count - MAX_JOBS + 1);
+  const idsToFetch = [];
+  for (let i = count; i >= startId; i--) {
+    idsToFetch.push(i.toString());
+  }
+
+  const results = await Promise.all(
+    idsToFetch.map(async (id) => {
+      try {
+        const job = await getJob(id);
+        if (job && job.status === "Open") {
+          return { id, job };
+        }
+      } catch {
+        return null;
+      }
+      return null;
+    })
+  );
+
+  const openJobs = results.filter(
+    (item): item is { id: string; job: Job } => item !== null
+  );
+
+  const jobsWithDesc = await Promise.all(
+    openJobs.map(async (item) => {
+      let description = "Description unavailable";
+      try {
+        const cid = await getDescriptionCid(item.job.description_hash);
+        if (cid) {
+          const text = await fetchFromIpfs(cid);
+          if (text) {
+            description = text;
+          }
+        }
+      } catch {
+        // Fallback
+      }
+      return { ...item, description };
+    })
+  );
+
+  function escapeXml(unsafe: string) {
+    return unsafe.replace(/[<>&'"]/g, (c) => {
+      switch (c) {
+        case "<": return "&lt;";
+        case ">": return "&gt;";
+        case "&": return "&amp;";
+        case "'": return "&apos;";
+        case "\"": return "&quot;";
+        default: return c;
+      }
+    });
+  }
+
+  const buildRSSItem = (item: { id: string; job: Job; description: string }) => {
+    const jobUrl = `${baseUrl}/job/${item.id}`;
+    const amountXlm = toXlm(item.job.amount);
+    const pubDate = new Date(Number(item.job.created_at) * 1000).toUTCString();
+    const deadlineDate = new Date(Number(item.job.deadline) * 1000).toUTCString();
+    
+    const client = item.job.client;
+    const clientShort = client ? `${client.substring(0, 6)}...${client.substring(client.length - 4)}` : "Unknown";
+
+    const content = `Amount: ${amountXlm} XLM\nDeadline: ${deadlineDate}\nClient: ${clientShort}\n\n${item.description}`;
+
+    return `
+    <item>
+      <title>${escapeXml(item.job.title || "Untitled Job")}</title>
+      <link>${jobUrl}</link>
+      <guid>${jobUrl}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXml(content)}</description>
+    </item>`;
+  };
+
+  const rss = `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>StellarWork Open Jobs</title>
+    <link>${baseUrl}</link>
+    <description>Latest open freelance jobs on StellarWork</description>
+    <language>en-us</language>
+    <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml" />${jobsWithDesc.map(buildRSSItem).join("")}
+  </channel>
+</rss>`;
+
+  return new Response(rss, {
+    headers: {
+      "Content-Type": "application/rss+xml",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+    },
+  });
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -100,6 +100,9 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: BASE_URL,
+    types: {
+      "application/rss+xml": "/feed.xml",
+    },
   },
 };
 


### PR DESCRIPTION
# Pull Request Template

## Linked Issue

Closes #729

## PR Title

feat(frontend): add RSS feed for open job listings

## What Changed

- **RSS Feed Route**: Added `app/feed.xml/route.ts` to dynamically generate a valid RSS 2.0 feed of the most recent open jobs (up to 50 jobs to ensure performance).
- **Server-side Caching**: Implemented a 5-minute cache TTL (`revalidate = 300`) on the route to prevent excessive reads against the Stellar network/contracts.
- **Feed Content**: Each item includes the job title, a short link, publishing date, and a description containing the amount (in XLM), deadline, truncated client address, and the actual job description fetched from IPFS.
- **Autodiscovery**: Updated `app/layout.tsx` to include the `alternates` metadata for `application/rss+xml`, enabling automatic discovery by RSS readers and aggregators.
- **Testing**: Added `__tests__/feed-route.test.ts` to cover the empty-feed scenario and validate the expected XML structure and fallback behaviors.

## Validation

- [x] I referenced the related issue in this PR.
- [ ] Contract checks pass (`soroban contract build` and `cargo test` in `contracts/escrow`) if contract code changed. *(N/A - no contract changes)*
- [x] Frontend checks/build pass for changed frontend files.
- [ ] I included screenshots or short clips for UI changes (or noted N/A). *(N/A - backend route and metadata changes only)*

## Additional Notes

- The RSS feed fetches the most recent job count and iterates backward to locate open jobs efficiently.
- If IPFS fetching fails for a specific job description, it falls back gracefully to a generic "Description unavailable" message to prevent the entire feed from breaking.
