### PR TITLE
fix: clear all wallet-specific cache data on disconnect

### DIFF
--- a/frontend/lib/wallet-context.tsx
+++ b/frontend/lib/wallet-context.tsx
@@ -56,13 +56,27 @@ const WalletContext = createContext<WalletContextType>({
   isSwitching: false,
 });
 
-/** Remove all job description cache entries from localStorage. */
-function clearJobCache() {
+/** Remove all wallet-specific cache entries from localStorage. */
+function clearWalletData() {
   if (typeof window === "undefined") return;
   const keysToRemove: string[] = [];
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
-    if (key?.startsWith(JOB_CACHE_PREFIX)) {
+    if (!key) continue;
+    
+    if (
+      key.startsWith(JOB_CACHE_PREFIX) ||
+      key.startsWith("stellarwork:post-job-draft:") ||
+      key.startsWith("stellarwork:dashboard-widgets:") ||
+      [
+        "stellarwork:notifications",
+        "stellarwork:bookmarked-jobs",
+        "stellarwork:resume-builder",
+        "stellarwork:recent-contract-interactions",
+        "sw:call-history",
+        "stellarwork:meetings"
+      ].includes(key)
+    ) {
       keysToRemove.push(key);
     }
   }
@@ -128,7 +142,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       try {
         const currentKey = await getPublicKey();
         if (currentKey && wallet && currentKey !== wallet) {
-          clearJobCache();
+          clearWalletData();
           setWallet(currentKey);
           persistLastAccount(currentKey);
           if (typeof window !== "undefined") {
@@ -164,7 +178,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     }
   }, [wallet]);
   const clearCachedData = useCallback(() => {
-    clearJobCache();
+    clearWalletData();
   }, []);
 
   const connectWallet = useCallback(async () => {
@@ -183,6 +197,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   }, [wallet, refreshWalletNetwork]);
 
   const disconnectWallet = useCallback(() => {
+    clearWalletData();
     setWallet(null);
     setWalletNetwork(null);
     persistLastAccount(null);
@@ -207,7 +222,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       // Re-request access so Freighter shows the account picker.
       const newKey = await stellarConnectWallet();
       if (newKey && newKey !== wallet) {
-        clearJobCache();
+        clearWalletData();
         setWallet(newKey);
         persistLastAccount(newKey);
       }


### PR DESCRIPTION
This PR resolves an issue where previously fetched job data (and other wallet-specific data) remained visible on the dashboard after a wallet disconnect. 

Changes made:
- Renamed `clearJobCache` to `clearWalletData` in `frontend/lib/wallet-context.tsx`.
- Expanded the cache clearing function to remove not only job descriptions but also other wallet-specific data stored in localStorage, including post-job drafts, dashboard widget configurations, notifications, bookmarked jobs, recent contract interactions, call history, and meetings.
- Ensured `clearWalletData()` is successfully called during the `disconnectWallet` event.

Close #840 