### PR TITLE
Fix stale job status on back navigation by refetching on visibility change

### DIFF
--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -142,9 +142,22 @@ export default function JobDetailPage() {
     }
   }
 
-  useEffect(() => {
+useEffect(() => {
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Refetch job data when the page becomes visible (e.g., after using browser back button)
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void load();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, [id]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #838 



## What Changed  

- Added a **`visibilitychange`** listener in `frontend/app/job/[id]/page.tsx`.  
- When the document becomes visible again (e.g., after the user navigates back with the browser back button), the job data is re‑loaded via the existing `load()` function.  
- This guarantees that the **Job Detail** page always reflects the current job status instead of a stale one after navigation.  
- No other parts of the codebase were modified.  

**Design trade‑offs:**  
- Using the `visibilitychange` event is lightweight and does not require additional state management or changes to the existing React Query caching strategy.  
- The extra `useEffect` runs only when the component is mounted and cleans up the event listener on unmount, so there is no memory leak risk.  

## Validation  

- [x] I referenced the related issue in this PR.  
- [ ] Contract checks pass (`soroban contract build` and `cargo test` in `contracts/escrow`) – *no contract changes were made.*  
- [x] Frontend checks/build pass for changed frontend files.  
- [x] I included screenshots or short clips for UI changes (or noted N/A). *N/A – the change is functional only.*  

## Additional Notes  

- The fix can be verified by opening a job in **Open** status, accepting it (status becomes **InProgress**), navigating away, then using the browser back button. The job detail now correctly shows **InProgress** without a manual refresh.  
- No further follow‑up work is required; the change is self‑contained.  