### PR TITLE
feat: Add client reputation score display on job cards

### DIFF
--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -7,6 +7,7 @@ import InfoTooltip from "@/components/InfoTooltip";
 import { useToast } from "@/components/ToastProvider";
 import StatusPill from "@/components/StatusPill";
 import ShareButton from "@/components/ShareButton";
+import ClientReputationBadge from "@/components/ClientReputationBadge";
 import dynamic from "next/dynamic";
 import { isRichText, PlainTextRenderer } from "@/lib/rich-text";
 import TruncatedAddress from "@/components/TruncatedAddress";
@@ -770,9 +771,11 @@ function JobDetailPageContent() {
             </button>
           </div>
         </div>
-        <p>
-          <strong>Client:</strong> {job.client}
-        </p>
+        <div className="flex items-center gap-2">
+          <strong>Client:</strong> 
+          <span>{job.client}</span>
+          <ClientReputationBadge clientAddress={job.client} />
+        </div>
         <p>
           <strong>Freelancer:</strong>{" "}
           {job.freelancer ? (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,6 +12,7 @@ import TruncatedAddress from "@/components/TruncatedAddress";
 import ComparisonBar from "@/components/ComparisonBar";
 import CancelJobConfirmModal from "@/components/CancelJobConfirmModal";
 import SwipeableJobCard from "@/components/SwipeableJobCard";
+import ClientReputationBadge from "@/components/ClientReputationBadge";
 import JobFilterPanel, { DEFAULT_FILTERS, type JobFilters } from "@/components/JobFilterPanel";
 import { acceptJob, cancelJob, getDescriptionCid, getJob, getJobCount } from "@/lib/contract";
 import { fetchFromIpfs } from "@/lib/ipfs-service";
@@ -1142,6 +1143,9 @@ export default function HomePage() {
                       ? `Deadline: ${deadline.isPast ? "Past due" : deadline.relative} • ${deadline.exact}`
                       : "Deadline: No deadline"}
                   </p>
+                  <div className="mt-2">
+                    <ClientReputationBadge clientAddress={job.client} />
+                  </div>
                 </div>
                 <div
                   className={`flex flex-wrap items-center gap-2 ${

--- a/frontend/components/ClientReputationBadge.tsx
+++ b/frontend/components/ClientReputationBadge.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getClientStats, type ClientStats } from "@/lib/client-reputation";
+
+export default function ClientReputationBadge({ clientAddress }: { clientAddress: string }) {
+  const [stats, setStats] = useState<ClientStats | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getClientStats(clientAddress)
+      .then((res) => {
+        if (mounted) setStats(res);
+      })
+      .catch(console.error);
+    return () => {
+      mounted = false;
+    };
+  }, [clientAddress]);
+
+  if (!stats) return <span className="inline-block h-5 w-16 animate-pulse rounded bg-slate-200"></span>;
+
+  if (stats.score === null) {
+    return (
+      <div className="group relative inline-flex items-center gap-1 rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+        <span>New Client</span>
+        <div className="absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs text-white group-hover:block">
+          Insufficient data (needs 3+ jobs)
+          <div className="absolute left-1/2 top-full -mt-1 h-2 w-2 -translate-x-1/2 rotate-45 bg-slate-800"></div>
+        </div>
+      </div>
+    );
+  }
+
+  const getScoreColor = (score: number) => {
+    if (score >= 4.5) return "bg-green-100 text-green-800";
+    if (score >= 3.5) return "bg-yellow-100 text-yellow-800";
+    return "bg-red-100 text-red-800";
+  };
+
+  return (
+    <div className={`group relative inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium cursor-help ${getScoreColor(stats.score)}`}>
+      <span>★ {stats.score.toFixed(1)}</span>
+      <div className="absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-3 py-2 text-xs text-white group-hover:block">
+        <p className="mb-1 font-semibold">Client Reputation</p>
+        <ul className="text-left font-normal text-slate-200">
+          <li>Jobs Posted: {stats.jobsPosted}</li>
+          <li>Completed: {stats.jobsCompleted}</li>
+          <li>Cancelled: {stats.jobsCancelled}</li>
+        </ul>
+        <p className="mt-1 border-t border-slate-600 pt-1 text-[10px] text-slate-400">Score based on completion rate</p>
+        <div className="absolute left-1/2 top-full -mt-1 h-2 w-2 -translate-x-1/2 rotate-45 bg-slate-800"></div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/client-reputation.ts
+++ b/frontend/lib/client-reputation.ts
@@ -1,0 +1,46 @@
+﻿import { getJob, getJobCount } from "./contract";
+
+export interface ClientStats {
+  jobsPosted: number;
+  jobsCompleted: number;
+  jobsCancelled: number;
+  score: number | null;
+}
+
+const cache: Record<string, { stats: ClientStats; timestamp: number }> = {};
+const CACHE_TTL = 5 * 60 * 1000;
+
+export async function getClientStats(clientAddress: string): Promise<ClientStats> {
+  const now = Date.now();
+  if (cache[clientAddress] && now - cache[clientAddress].timestamp < CACHE_TTL) {
+    return cache[clientAddress].stats;
+  }
+
+  const count = await getJobCount();
+  let jobsPosted = 0;
+  let jobsCompleted = 0;
+  let jobsCancelled = 0;
+
+  for (let id = 1; id <= count; id++) {
+    const job = await getJob(String(id));
+    if (!job) continue;
+    if (job.client === clientAddress) {
+      jobsPosted++;
+      if (job.status === "Completed") {
+        jobsCompleted++;
+      } else if (job.status === "Cancelled") {
+        jobsCancelled++;
+      }
+    }
+  }
+
+  let score: number | null = null;
+  if (jobsPosted >= 3) {
+    const completionRate = jobsCompleted / jobsPosted;
+    score = Math.round(completionRate * 50) / 10;
+  }
+
+  const stats = { jobsPosted, jobsCompleted, jobsCancelled, score };
+  cache[clientAddress] = { stats, timestamp: now };
+  return stats;
+}


### PR DESCRIPTION
Closes #811

## Feature Description
Show client reputation metrics to help freelancers evaluate opportunities.

## Proposed Solution
- Calculate client score from completion rate and history
- Display score badge on job cards and detail page
- Show breakdown (jobs posted, completed, cancelled)
- Add tooltip explaining score calculation
- Hide score for new clients with insufficient data