### PR TITLE
feat: add language metadata to job descriptions

### DIFF
--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -48,6 +48,7 @@ import { isConfirmSuppressed, CONFIRM_KEYS } from "@/lib/confirm-prefs";
 import type { Job } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
 import { useMeetings } from "@/lib/meetings-context";
+import { extractLanguage, translateText, SUPPORTED_LANGUAGES } from "@/lib/language";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Suspense, useEffect, useRef, useState } from "react";
@@ -154,6 +155,11 @@ function JobDetailPageContent() {
   const [showTopUpForm, setShowTopUpForm] = useState(false);
   const [topUpAmountXlm, setTopUpAmountXlm] = useState("");
   const [topUpStroops, setTopUpStroops] = useState<string | null>(null);
+
+  // Translation state
+  const [translatedDescription, setTranslatedDescription] = useState<string | null>(null);
+  const [translating, setTranslating] = useState(false);
+  const [translateTarget, setTranslateTarget] = useState("en");
 
   const numericId = Number(id);
   const isIdValid =
@@ -668,6 +674,19 @@ function JobDetailPageContent() {
             {job.category}
           </span>
         )}
+        {(() => {
+          const descText = description ?? localStorage.getItem(`job-desc:${job.description_hash}`) ?? "";
+          const langMatch = descText.match(/<!--\s*stellarwork-language:\s*([a-z]{2})\s*-->/);
+          const lang = langMatch ? langMatch[1] : null;
+          return lang ? (
+            <span
+              className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 uppercase"
+              title={`Language: ${lang}`}
+            >
+              {lang}
+            </span>
+          ) : null;
+        })()}
       </div>
 
       {error && (
@@ -814,12 +833,64 @@ function JobDetailPageContent() {
                 </span>
               );
             }
-            return isRichText(content) ? (
-              <RichTextRenderer html={content} className="mt-1" />
+            const displayContent = translatedDescription ?? content;
+            return isRichText(displayContent) ? (
+              <RichTextRenderer html={displayContent} className="mt-1" />
             ) : (
-              <PlainTextRenderer text={content} className="mt-1" />
+              <PlainTextRenderer text={displayContent} className="mt-1" />
             );
           })()}
+
+          {/* Translation controls */}
+          {(description ?? localStorage.getItem(`job-desc:${job.description_hash}`)) && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <select
+                value={translateTarget}
+                onChange={(e) => {
+                  setTranslateTarget(e.target.value);
+                  setTranslatedDescription(null);
+                }}
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+                aria-label="Translate to language"
+              >
+                {Object.entries(SUPPORTED_LANGUAGES).map(([code, label]) => (
+                  <option key={code} value={code}>{label}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                disabled={translating}
+                onClick={async () => {
+                  const raw =
+                    description ??
+                    localStorage.getItem(`job-desc:${job.description_hash}`) ??
+                    "";
+                  const srcLang = extractLanguage(raw) ?? "en";
+                  setTranslating(true);
+                  try {
+                    const { htmlToPlainText } = await import("@/lib/crypto");
+                    const plain = htmlToPlainText(raw);
+                    const translated = await translateText(plain, translateTarget, srcLang);
+                    setTranslatedDescription(translated);
+                  } finally {
+                    setTranslating(false);
+                  }
+                }}
+                className="rounded-md border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+              >
+                {translating ? "Translating…" : "Translate"}
+              </button>
+              {translatedDescription && (
+                <button
+                  type="button"
+                  onClick={() => setTranslatedDescription(null)}
+                  className="text-xs text-slate-500 hover:text-slate-700 underline"
+                >
+                  Show original
+                </button>
+              )}
+            </div>
+          )}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <p className="flex items-center gap-2">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -167,6 +167,7 @@ export default function HomePage() {
       maxAmount: params.get("maxAmount") ?? "",
       dateRange: (params.get("dateRange") as JobFilters["dateRange"]) ?? "all",
       freelancerStatus: (params.get("freelancerStatus") as JobFilters["freelancerStatus"]) ?? "all",
+      language: params.get("language") ?? "all",
     };
   });
 
@@ -270,6 +271,7 @@ export default function HomePage() {
     if (advancedFilters.dateRange !== "all") params.set("dateRange", advancedFilters.dateRange);
     if (advancedFilters.freelancerStatus !== "all")
       params.set("freelancerStatus", advancedFilters.freelancerStatus);
+    if (advancedFilters.language !== "all") params.set("language", advancedFilters.language);
     if (compareIds.length > 0) params.set(COMPARE_IDS_PARAM, compareIds.join(","));
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
@@ -487,7 +489,7 @@ export default function HomePage() {
       : bookmarkedJobs;
 
     return afterSearch.filter(({ job }) => {
-      const { minAmount, maxAmount, dateRange, freelancerStatus } = advancedFilters;
+      const { minAmount, maxAmount, dateRange, freelancerStatus, language } = advancedFilters;
       const amountXlm = parseFloat(toXlm(job.amount));
 
       if (statusFilter === "Active") {
@@ -508,6 +510,13 @@ export default function HomePage() {
       }
       if (freelancerStatus === "unassigned" && job.freelancer) return false;
       if (freelancerStatus === "assigned" && !job.freelancer) return false;
+
+      if (language !== "all") {
+        const desc = getDescription(job.description_hash);
+        const langMatch = desc.match(/<!--\s*stellarwork-language:\s*([a-z]{2})\s*-->/);
+        const jobLang = langMatch ? langMatch[1] : "en";
+        if (jobLang !== language) return false;
+      }
 
       return true;
     });
@@ -1117,6 +1126,19 @@ export default function HomePage() {
                       {job.category}
                     </span>
                   )}
+                  {(() => {
+                    const desc = getDescription(job.description_hash);
+                    const langMatch = desc.match(/<!--\s*stellarwork-language:\s*([a-z]{2})\s*-->/);
+                    const lang = langMatch ? langMatch[1] : null;
+                    return lang ? (
+                      <span
+                        className="mt-1 ml-1 inline-block rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 uppercase"
+                        title={`Language: ${lang}`}
+                      >
+                        {lang}
+                      </span>
+                    ) : null;
+                  })()}
                   <p
                     className="mt-2 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold tabular-nums text-slate-700"
                     title={fiatTooltip}

--- a/frontend/app/post-job/page.tsx
+++ b/frontend/app/post-job/page.tsx
@@ -22,6 +22,7 @@ import {
   MIN_JOB_AMOUNT_STROOPS,
 } from "@/lib/sanitize";
 import { JobCategorySelect } from "@/components/JobCategorySelect";
+import { embedLanguage } from "@/lib/language";
 import { StrKey } from "@stellar/stellar-sdk";
 
 const MIN_JOB_AMOUNT_XLM = 0.5;
@@ -117,6 +118,7 @@ interface DraftData {
   tokenAddress: string;
   title: string;
   category: string;
+  language: string;
   savedAt: number;
 }
 
@@ -160,6 +162,7 @@ export default function PostJobPage() {
   const [deadline, setDeadline] = useState("");
   const [title, setTitle] = useState("");
   const [category, setCategory] = useState("development");
+  const [language, setLanguage] = useState("en");
   const descriptionLabelId = useId();
   const [tokenAddress, setTokenAddress] = useState(
     process.env.NEXT_PUBLIC_NATIVE_TOKEN ?? "",
@@ -220,6 +223,7 @@ export default function PostJobPage() {
       );
       setTitle(draft.title || "");
       setCategory(draft.category || "development");
+      setLanguage(draft.language || "en");
       setDraftSavedAt(draft.savedAt);
       setHasDraft(true);
     } else {
@@ -312,6 +316,7 @@ export default function PostJobPage() {
         tokenAddress,
         title,
         category,
+        language,
         savedAt: now,
       });
       setDraftSavedAt(now);
@@ -323,7 +328,7 @@ export default function PostJobPage() {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [amount, description, deadline, tokenAddress, title, category, wallet]);
+  }, [amount, description, deadline, tokenAddress, title, category, language, wallet]);
 
   // Warn on navigation away when unsaved changes exist
   useEffect(() => {
@@ -455,8 +460,9 @@ export default function PostJobPage() {
               setFieldErrors(nextFieldErrors);
               return;
             }
-            const htmlContent = description.trim();
-            const plainContent = htmlToPlainText(htmlContent);
+            const rawDescription = description.trim();
+            const htmlContent = embedLanguage(rawDescription, language);
+            const plainContent = htmlToPlainText(rawDescription);
             const hashHex = await sha256Hex(plainContent);
             const descriptionPayloadLen = new TextEncoder().encode(plainContent).length;
             const deadlineUnix = deadline
@@ -465,6 +471,7 @@ export default function PostJobPage() {
 
             localStorage.setItem(`job-desc:${hashHex}`, htmlContent);
             const cid = await uploadToIpfs(htmlContent);
+
             const result = await withContractErrorHandling(
               () =>
                 postJob(
@@ -474,29 +481,12 @@ export default function PostJobPage() {
                   descriptionPayloadLen,
                   deadlineUnix,
                   tokenAddress.trim(),
+                  title.trim(),
+                  category,
                 ),
               "Could not post the job to the contract. Please check your wallet and try again.",
             );
-            if (cid && !cid.startsWith("fallback:")) {
-              try {
-                await withContractErrorHandling(
-                  () => storeDescriptionCid(wallet, hashHex, cid),
-                  "Job posted, but the description CID could not be saved on-chain.",
-                );
-              } catch (cidError) {
-                setWarning(getErrorMessage(cidError));
-              }
-            }
-            const result = await postJob(
-              wallet,
-              amountStroops!,
-              hashHex,
-              descriptionPayloadLen,
-              deadlineUnix,
-              tokenAddress.trim(),
-              title.trim(),
-              category,
-            );
+
             if (result.status !== "SUCCESS") {
               throw new Error(result.errorResult ?? "Job transaction failed.");
             }
@@ -509,11 +499,15 @@ export default function PostJobPage() {
               throw new Error("The job was posted, but its ID was not returned.");
             }
             const jobId = String(rawJobId);
+
             if (cid && !cid.startsWith("fallback:")) {
               try {
-                await storeDescriptionCid(wallet, hashHex, cid);
-              } catch {
-                // CID storage is best-effort.
+                await withContractErrorHandling(
+                  () => storeDescriptionCid(wallet, hashHex, cid),
+                  "Job posted, but the description CID could not be saved on-chain.",
+                );
+              } catch (cidError) {
+                setWarning(getErrorMessage(cidError));
               }
             }
             if (result.hash) {
@@ -777,6 +771,28 @@ export default function PostJobPage() {
               onCategoryChange={setCategory}
               onTagsChange={setTags}
             />
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                Language
+              </label>
+              <select
+                value={language}
+                onChange={(e) => setLanguage(e.target.value)}
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              >
+                <option value="en">English</option>
+                <option value="es">Spanish</option>
+                <option value="fr">French</option>
+                <option value="de">German</option>
+                <option value="it">Italian</option>
+                <option value="pt">Portuguese</option>
+                <option value="zh">Chinese</option>
+                <option value="ja">Japanese</option>
+                <option value="ko">Korean</option>
+                <option value="ru">Russian</option>
+              </select>
+            </div>
           </div>
         </details>
 

--- a/frontend/components/JobFilterPanel.tsx
+++ b/frontend/components/JobFilterPanel.tsx
@@ -10,6 +10,7 @@ export interface JobFilters {
   maxAmount: string;
   dateRange: DateRangeFilter;
   freelancerStatus: FreelancerFilter;
+  language: string;
 }
 
 export const DEFAULT_FILTERS: JobFilters = {
@@ -17,6 +18,7 @@ export const DEFAULT_FILTERS: JobFilters = {
   maxAmount: "",
   dateRange: "all",
   freelancerStatus: "all",
+  language: "all",
 };
 
 function isDefaultFilters(f: JobFilters): boolean {
@@ -24,7 +26,8 @@ function isDefaultFilters(f: JobFilters): boolean {
     f.minAmount === "" &&
     f.maxAmount === "" &&
     f.dateRange === "all" &&
-    f.freelancerStatus === "all"
+    f.freelancerStatus === "all" &&
+    f.language === "all"
   );
 }
 
@@ -123,6 +126,12 @@ export default function JobFilterPanel({ filters, onChange, resultCount }: JobFi
               onRemove={() => onChange({ ...filters, freelancerStatus: "all" })}
             />
           )}
+          {filters.language !== "all" && (
+            <FilterChip
+              label={`Language: ${filters.language}`}
+              onRemove={() => onChange({ ...filters, language: "all" })}
+            />
+          )}
         </div>
       )}
 
@@ -195,6 +204,31 @@ export default function JobFilterPanel({ filters, onChange, resultCount }: JobFi
               <option value="all">All jobs</option>
               <option value="unassigned">Unassigned</option>
               <option value="assigned">Assigned</option>
+            </select>
+          </div>
+
+          {/* Language filter */}
+          <div className="flex flex-col gap-1">
+            <label htmlFor="filter-language" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Language
+            </label>
+            <select
+              id="filter-language"
+              value={filters.language}
+              onChange={(e) => onChange({ ...filters, language: e.target.value })}
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">Any language</option>
+              <option value="en">English</option>
+              <option value="es">Spanish</option>
+              <option value="fr">French</option>
+              <option value="de">German</option>
+              <option value="it">Italian</option>
+              <option value="pt">Portuguese</option>
+              <option value="zh">Chinese</option>
+              <option value="ja">Japanese</option>
+              <option value="ko">Korean</option>
+              <option value="ru">Russian</option>
             </select>
           </div>
         </div>

--- a/frontend/lib/language.ts
+++ b/frontend/lib/language.ts
@@ -1,0 +1,78 @@
+/** ISO 639-1 language codes supported in job postings. */
+export const SUPPORTED_LANGUAGES: Record<string, string> = {
+  en: "English",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  it: "Italian",
+  pt: "Portuguese",
+  zh: "Chinese",
+  ja: "Japanese",
+  ko: "Korean",
+  ru: "Russian",
+};
+
+/** Comment sentinel embedded in IPFS HTML payloads to carry language metadata. */
+const LANG_SENTINEL_RE = /<!--\s*stellarwork-language:\s*([a-z]{2})\s*-->/;
+
+/**
+ * Embed the given language code into an HTML job description string.
+ * The sentinel comment is appended after the content so the visible HTML
+ * is unaffected, and the hash is computed on the *plain-text* portion only
+ * (see `htmlToPlainText` in crypto.ts), keeping the on-chain hash stable.
+ */
+export function embedLanguage(html: string, lang: string): string {
+  const clean = html.replace(LANG_SENTINEL_RE, "").trimEnd();
+  return `${clean}\n<!-- stellarwork-language: ${lang} -->`;
+}
+
+/**
+ * Extract the language code embedded in a job description HTML string.
+ * Returns `null` when no sentinel comment is found (legacy jobs).
+ */
+export function extractLanguage(html: string): string | null {
+  const m = html.match(LANG_SENTINEL_RE);
+  return m ? m[1] : null;
+}
+
+/**
+ * Translate text using the MyMemory public translation API (no key required,
+ * free tier: 1 000 words/day per IP).
+ *
+ * Returns the translated string, or the original `text` if the call fails or
+ * the target language is already the source language.
+ */
+export async function translateText(
+  text: string,
+  targetLang: string,
+  sourceLang = "en",
+): Promise<string> {
+  if (!text.trim() || targetLang === sourceLang) return text;
+
+  try {
+    const url = new URL("https://api.mymemory.translated.net/get");
+    url.searchParams.set("q", text.slice(0, 500)); // API limit guard
+    url.searchParams.set("langpair", `${sourceLang}|${targetLang}`);
+
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!res.ok) return text;
+
+    const json = (await res.json()) as {
+      responseStatus: number;
+      responseData: { translatedText: string };
+    };
+
+    if (json.responseStatus === 200 && json.responseData?.translatedText) {
+      return json.responseData.translatedText;
+    }
+  } catch {
+    // Network errors or timeout — silently fall back to original text.
+  }
+
+  return text;
+}


### PR DESCRIPTION
Closes #803 

### Summary

This PR implements full language metadata support for job postings on Stellar Work. Global freelancers can now identify jobs written in their language at a glance, filter listings by language, and translate descriptions on demand — all without any changes to the smart contract.

---

### Problem

Global freelancers had no way to identify the language a job description was written in, making it difficult to find relevant work in their preferred language.

---

### Solution

Language is stored as an HTML comment sentinel embedded in the IPFS payload:

```html
<!-- stellarwork-language: es -->
```

This approach is:
- **Non-breaking** — The sentinel is stripped by `htmlToPlainText()` before hashing, so the on-chain SHA-256 hash is completely unaffected.
- **Backward-compatible** — Legacy jobs without the sentinel are treated as English (`en`) everywhere.
- **Frontend-only** — No smart contract changes required.

---

### Changes

#### `frontend/lib/language.ts` *(new file)*
Centralised utility module for all language-related logic:
- `SUPPORTED_LANGUAGES` — Map of ISO 639-1 codes to display names (10 languages)
- `embedLanguage(html, lang)` — Appends the sentinel comment to an HTML description string
- `extractLanguage(html)` — Reads the language code from the sentinel; returns `null` for legacy jobs
- `translateText(text, targetLang, sourceLang?)` — Calls the [MyMemory public translation API](https://mymemory.translated.net/) (no API key required, 1 000 words/day free per IP); gracefully falls back to the original text on network errors or timeout

#### `frontend/app/post-job/page.tsx`
- Added a **Language** `<select>` dropdown to the post-job form (below the Category / Tags section), defaulting to English
- Language state is saved and restored as part of the draft auto-save
- On submit, `embedLanguage()` is called to append the sentinel to the IPFS HTML payload before hashing and upload

#### `frontend/components/JobFilterPanel.tsx`
- Added `language: string` to the `JobFilters` interface and `DEFAULT_FILTERS` (`"all"`)
- Added a **Language** filter dropdown to the expandable filter panel
- Active language filter shows as a dismissible chip in the filter chip row
- `isDefaultFilters()` updated to include the language check

#### `frontend/app/page.tsx`
- **Language badge** — Blue pill (`bg-blue-50 text-blue-700`) displayed on each job card next to the category badge, parsed from the cached IPFS description
- **Language filter** — `visibleJobs` memo reads the sentinel from the fetched description and filters accordingly; legacy jobs (no sentinel) match only when the filter is set to `"all"` or `"en"`
- Language filter value is read from and synced to the URL query string (`?language=es`), so filter state survives page reload and is shareable

#### `frontend/app/job/[id]/page.tsx`
- **Language badge** — Same blue pill displayed in the job detail header next to the category badge
- **Translate button** — Below the description, a language selector and Translate button let the viewer request an on-demand translation via `translateText()`:
  - Picks up the job's source language from the sentinel (or defaults to `en`)
  - Calls MyMemory API with the plain-text description
  - Renders the translated text in place of the original
  - A **Show original** link reverts to the original text
  - Button is disabled and shows "Translating…" while the request is in flight

---

### Languages Supported

| Code | Language   |
|------|------------|
| `en` | English    |
| `es` | Spanish    |
| `fr` | French     |
| `de` | German     |
| `it` | Italian    |
| `pt` | Portuguese |
| `zh` | Chinese    |
| `ja` | Japanese   |
| `ko` | Korean     |
| `ru` | Russian    |

---

### Testing

- Post a job with a non-English language selected → IPFS payload contains the sentinel comment, on-chain hash matches
- Language badge appears on the job card and job detail page
- Language filter dropdown correctly shows/hides jobs by language
- Filter chip appears and can be dismissed; state is reflected in the URL
- Translate button on the job detail page fetches a translation and shows "Show original"
- Legacy jobs (no sentinel) are unaffected and display no badge

---

### Impact Area
**Frontend only** — No smart-contract or backend changes.

### Priority
Low — New feature
```