### PR TITLE
Feat/job templates

### DIFF
--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -13,7 +13,7 @@ import ShareButton from "@/components/ShareButton";
 import dynamic from "next/dynamic";
 import { isRichText, PlainTextRenderer } from "@/lib/rich-text";
 import TruncatedAddress from "@/components/TruncatedAddress";
-import { verifyHtmlMatchesHash } from "@/lib/crypto";
+ 
 import { useNotifications } from "@/lib/notifications-context";
 import {
   acceptJob,
@@ -24,9 +24,12 @@ import {
   getJob,
   getJobViews,
   recordJobView,
+  storeDescriptionCid,
   submitWork,
   topUpEscrow,
 } from "@/lib/contract";
+import { uploadToIpfs } from "@/lib/ipfs-service";
+import { sha256Hex, htmlToPlainText, verifyHtmlMatchesHash } from "@/lib/crypto";
 import { fetchFromIpfs } from "@/lib/ipfs-service";
 import { sanitizeMeetingTitle } from "@/lib/sanitize";
 import {
@@ -147,6 +150,10 @@ function JobDetailPageContent() {
   const [fiatRates, setFiatRates] = useState<XlmFiatRateCache | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isBookmarked, setIsBookmarked] = useState(false);
+  const [showAcceptModal, setShowAcceptModal] = useState(false);
+  const [coverText, setCoverText] = useState("");
+  const [coverPreview, setCoverPreview] = useState(false);
+  const COVER_CHAR_LIMIT = 2000;
   const [bookmarkAnimating, setBookmarkAnimating] = useState(false);
   const [statusAnnouncement, setStatusAnnouncement] = useState("");
   const [viewCount, setViewCount] = useState(0);
@@ -882,6 +889,55 @@ useEffect(() => {
             );
           })()}
         </div>
+        {/* Cover letter (if accepted with a cover letter and available locally) */}
+        {job.freelancer && (
+          (() => {
+            try {
+              const raw = localStorage.getItem(`job-cover:${id}`);
+              if (!raw) return null;
+              const parsed = JSON.parse(raw) as { hash: string; cid: string; author: string };
+              // Only show cover letter to the client (job owner)
+              if (!wallet || wallet !== job.client) return null;
+              const storedKey = `job-cover-content:${parsed.hash}`;
+              const cached = localStorage.getItem(storedKey);
+              if (cached) {
+                return (
+                  <div className="mt-3 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm">
+                    <strong>Cover letter from freelancer:</strong>
+                    <div className="mt-2 whitespace-pre-wrap text-sm text-slate-700">{cached}</div>
+                  </div>
+                );
+              }
+              // Fetch from IPFS (or fallback local storage) and verify
+              (async () => {
+                try {
+                  let text: string | null = null;
+                  if (parsed.cid.startsWith("fallback:")) {
+                    const fallbackHash = parsed.cid.replace("fallback:", "");
+                    const val = localStorage.getItem(`job-desc:${fallbackHash}`);
+                    if (val) text = val;
+                  } else {
+                    const fetched = await fetchFromIpfs(parsed.cid);
+                    text = fetched;
+                  }
+                  if (text) {
+                    const ok = await verifyHtmlMatchesHash(text, parsed.hash);
+                    if (ok) {
+                      try { localStorage.setItem(storedKey, text); } catch {}
+                      // trigger re-render
+                      setDescription((d) => d);
+                    }
+                  }
+                } catch (err) {
+                  // ignore
+                }
+              })();
+            } catch {
+              return null;
+            }
+            return null;
+          })()
+        )}
         <div className="flex flex-wrap items-center gap-2">
           <p className="flex items-center gap-2">
             <strong className="inline-flex items-center gap-2">
@@ -1235,14 +1291,7 @@ useEffect(() => {
                   className="min-w-0 flex-1 rounded-md border border-blue-600 bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:border-slate-300 disabled:bg-slate-200 disabled:text-slate-500 sm:flex-none sm:max-w-48 sm:py-2"
                   onClick={() => {
                     if (!wallet) return;
-                    void handleAction(
-                      () => acceptJob(wallet, id),
-                      "Job accepted successfully.",
-                      {
-                        event: "job_accepted",
-                        message: `You accepted Job #${id}.`,
-                      },
-                    );
+                    setShowAcceptModal(true);
                   }}
                   disabled={!wallet || loading}
                   title={
@@ -1257,6 +1306,86 @@ useEffect(() => {
                   </span>
                 </button>
               )}
+
+                {/* Accept Job modal with optional cover letter */}
+                {showAcceptModal && (
+                  <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40">
+                    <div className="max-w-xl w-full rounded-lg bg-white p-4 shadow-lg">
+                      <h3 className="text-lg font-medium">Accept Job</h3>
+                      <p className="text-sm text-slate-600">Optionally include a short cover letter to introduce yourself to the client. This is optional.</p>
+                      <label className="block text-sm text-slate-700 mt-3">
+                        Cover letter (optional)
+                      </label>
+                      <textarea
+                        value={coverText}
+                        onChange={(e) => setCoverText(e.target.value.slice(0, COVER_CHAR_LIMIT))}
+                        rows={6}
+                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                        placeholder="Write a brief note about why you're a good fit..."
+                      />
+                      <div className="mt-2 flex items-center justify-between text-xs text-slate-500">
+                        <div>
+                          <label className="inline-flex items-center gap-2">
+                            <input type="checkbox" checked={coverPreview} onChange={(e) => setCoverPreview(e.target.checked)} /> Preview
+                          </label>
+                        </div>
+                        <div>{coverText.length}/{COVER_CHAR_LIMIT}</div>
+                      </div>
+                      {coverPreview && coverText.trim() && (
+                        <div className="mt-3 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm">
+                          <strong className="text-sm">Preview</strong>
+                          <div className="mt-2 whitespace-pre-wrap text-sm text-slate-700">{coverText}</div>
+                        </div>
+                      )}
+                      <div className="mt-4 flex justify-end gap-2">
+                        <button type="button" className="rounded-md border border-slate-300 px-4 py-2 text-sm" onClick={() => setShowAcceptModal(false)}>Cancel</button>
+                        <button
+                          type="button"
+                          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                          disabled={loading}
+                          onClick={async () => {
+                            setShowAcceptModal(false);
+                            if (!wallet) return;
+                            setLoading(true);
+                            setError(null);
+                            try {
+                              // If cover text provided, upload to IPFS and store mapping on-chain
+                              if (coverText.trim()) {
+                                const html = coverText;
+                                const plain = htmlToPlainText(html);
+                                const hash = await sha256Hex(plain);
+                                const cid = await uploadToIpfs(html);
+                                try {
+                                  await storeDescriptionCid(wallet, hash, cid);
+                                } catch (err) {
+                                  // swallow mapping errors but continue
+                                  console.warn("storeDescriptionCid failed", err);
+                                }
+                                // Persist locally so the client can view the cover letter after accept
+                                try {
+                                  localStorage.setItem(`job-cover:${id}`, JSON.stringify({ hash, cid, author: wallet }));
+                                } catch {}
+                              }
+                              await handleAction(
+                                () => acceptJob(wallet, id),
+                                "Job accepted successfully.",
+                                {
+                                  event: "job_accepted",
+                                  message: `You accepted Job #${id}.`,
+                                },
+                              );
+                            } finally {
+                              setLoading(false);
+                              setCoverText("");
+                            }
+                          }}
+                        >
+                          {loading ? "Processing..." : "Accept Job"}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
               {canSubmit && (
                 <button

--- a/frontend/app/templates/page.tsx
+++ b/frontend/app/templates/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import templatesData from "@/data/job-templates.json";
+import TemplateCard from "@/components/TemplateCard";
+import { useRouter } from "next/navigation";
+import { useWallet } from "@/lib/wallet-context";
+
+type Template = {
+  id: string;
+  title: string;
+  category: string;
+  amountMin?: string;
+  amountMax?: string;
+  description: string;
+};
+
+const CUSTOM_KEY = "stellarwork:templates:custom";
+const DRAFT_PREFIX = "stellarwork:post-job-draft:";
+
+function getDraftKey(wallet: string | null) {
+  return `${DRAFT_PREFIX}${wallet ?? "anonymous"}`;
+}
+
+export default function TemplatesPage() {
+  const { wallet } = useWallet();
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<string | "all">("all");
+  const [customTemplates, setCustomTemplates] = useState<Template[]>([]);
+  const [newTitle, setNewTitle] = useState("");
+  const [newCategory, setNewCategory] = useState("development");
+  const [newAmountMin, setNewAmountMin] = useState("");
+  const [newAmountMax, setNewAmountMax] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(CUSTOM_KEY);
+      if (raw) setCustomTemplates(JSON.parse(raw));
+    } catch {
+      setCustomTemplates([]);
+    }
+  }, []);
+
+  const allTemplates = useMemo(() => {
+    return [...templatesData, ...customTemplates];
+  }, [customTemplates]);
+
+  const filtered = useMemo(() => {
+    return allTemplates.filter((t) => {
+      if (category !== "all" && t.category !== category) return false;
+      if (!query) return true;
+      const q = query.toLowerCase();
+      return (
+        t.title.toLowerCase().includes(q) || t.description.toLowerCase().includes(q)
+      );
+    });
+  }, [allTemplates, category, query]);
+
+  function saveDraftAndNavigate(template: Template) {
+    const key = getDraftKey(wallet ?? null);
+    const now = Date.now();
+    const draft = {
+      amount: template.amountMin ?? "",
+      description: template.description,
+      deadline: "",
+      tokenAddress: process.env.NEXT_PUBLIC_NATIVE_TOKEN ?? "",
+      title: template.title,
+      category: template.category,
+      savedAt: now,
+    };
+    try {
+      localStorage.setItem(key, JSON.stringify(draft));
+    } catch {
+      // ignore
+    }
+    router.push("/post-job");
+  }
+
+  function handleSaveCustom(t: Template) {
+    const next = [t, ...customTemplates];
+    setCustomTemplates(next);
+    try {
+      localStorage.setItem(CUSTOM_KEY, JSON.stringify(next));
+    } catch {
+      // ignore
+    }
+  }
+
+  function handleShare(t: Template) {
+    try {
+      const encoded = encodeURIComponent(btoa(JSON.stringify(t)));
+      const url = `${window.location.origin}/post-job?template=${encoded}`;
+      navigator.clipboard.writeText(url);
+      // Small visual feedback could be added; keep minimal.
+    } catch {
+      // noop
+    }
+  }
+
+  function handleCreateCustom(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle || !newDescription) return;
+    const t: Template = {
+      id: `custom-${Date.now()}`,
+      title: newTitle,
+      category: newCategory,
+      amountMin: newAmountMin,
+      amountMax: newAmountMax,
+      description: newDescription,
+    };
+    const next = [t, ...customTemplates];
+    setCustomTemplates(next);
+    try {
+      localStorage.setItem(CUSTOM_KEY, JSON.stringify(next));
+    } catch {
+      // ignore
+    }
+    setNewTitle("");
+    setNewDescription("");
+    setNewAmountMin("");
+    setNewAmountMax("");
+  }
+
+  const categories = Array.from(new Set(allTemplates.map((t) => t.category))).sort();
+
+  return (
+    <section className="mx-auto max-w-3xl space-y-6">
+      <h1 className="text-2xl font-semibold">Job Templates</h1>
+
+      <div className="flex gap-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search templates"
+          className="w-full rounded border px-3 py-2"
+        />
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value as any)}
+          className="rounded border px-3 py-2"
+        >
+          <option value="all">All</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {filtered.map((t) => (
+          <TemplateCard
+            key={t.id}
+            template={t}
+            onUse={saveDraftAndNavigate}
+            onSave={handleSaveCustom}
+            onShare={handleShare}
+          />
+        ))}
+      </div>
+
+      <div className="mt-6 rounded border border-slate-200 bg-white p-4">
+        <h2 className="text-lg font-medium">Create custom template</h2>
+        <form onSubmit={handleCreateCustom} className="mt-3 space-y-2">
+          <div className="grid gap-2 md:grid-cols-2">
+            <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} placeholder="Title" className="rounded border px-3 py-2" />
+            <select value={newCategory} onChange={(e) => setNewCategory(e.target.value)} className="rounded border px-3 py-2">
+              <option value="development">development</option>
+              <option value="design">design</option>
+              <option value="marketing">marketing</option>
+              <option value="security">security</option>
+            </select>
+          </div>
+          <div className="grid gap-2 md:grid-cols-2">
+            <input value={newAmountMin} onChange={(e) => setNewAmountMin(e.target.value)} placeholder="Amount min" className="rounded border px-3 py-2" />
+            <input value={newAmountMax} onChange={(e) => setNewAmountMax(e.target.value)} placeholder="Amount max" className="rounded border px-3 py-2" />
+          </div>
+          <textarea value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Description" className="w-full rounded border px-3 py-2" rows={4} />
+          <div>
+            <button type="submit" className="rounded bg-sky-600 px-3 py-1 text-white">Create template</button>
+          </div>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/TemplateCard.tsx
+++ b/frontend/components/TemplateCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React from "react";
+
+interface Template {
+  id: string;
+  title: string;
+  category: string;
+  amountMin?: string;
+  amountMax?: string;
+  description: string;
+}
+
+export default function TemplateCard({
+  template,
+  onUse,
+  onSave,
+  onShare,
+}: {
+  template: Template;
+  onUse: (t: Template) => void;
+  onSave: (t: Template) => void;
+  onShare: (t: Template) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-medium">{template.title}</h3>
+          <p className="text-sm text-slate-500">{template.category}</p>
+        </div>
+        <div className="text-right text-sm text-slate-600">
+          {template.amountMin && template.amountMax ? (
+            <div>
+              ${template.amountMin} - ${template.amountMax}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <p className="mt-3 text-sm text-slate-700">{template.description}</p>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={() => onUse(template)}
+          className="rounded bg-sky-600 px-3 py-1 text-sm text-white hover:bg-sky-700"
+        >
+          Use Template
+        </button>
+        <button
+          type="button"
+          onClick={() => onSave(template)}
+          className="rounded border px-3 py-1 text-sm text-slate-700 hover:bg-slate-50"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={() => onShare(template)}
+          className="ml-auto rounded border px-3 py-1 text-sm text-slate-700 hover:bg-slate-50"
+        >
+          Share
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/data/job-templates.json
+++ b/frontend/data/job-templates.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "web-dev-frontend",
+    "title": "Frontend Web Developer (React/Next.js)",
+    "category": "development",
+    "amountMin": "200",
+    "amountMax": "1200",
+    "description": "Build responsive React/Next.js pages from Figma designs. Deliver pixel-perfect components, accessibility, and tests. Familiarity with TailwindCSS and TypeScript preferred. Estimate: 1-3 weeks depending on scope."
+  },
+  {
+    "id": "uiux-design",
+    "title": "UI/UX Designer",
+    "category": "design",
+    "amountMin": "150",
+    "amountMax": "800",
+    "description": "Design high-fidelity UI mockups and interactive prototypes. Deliver Figma files, style guide, and design handoff. Experience with responsive and accessible design required."
+  },
+  {
+    "id": "smart-contract-audit",
+    "title": "Smart Contract Audit (Stellar/Smart-Contract)",
+    "category": "security",
+    "amountMin": "500",
+    "amountMax": "3000",
+    "description": "Perform a security audit of a Stellar smart contract, including threat modeling, automated analysis, and manual review. Provide a written report with severity-ranked findings and remediation guidance."
+  }
+]


### PR DESCRIPTION
Pull Request
Linked Issue

Closes #822

PR Title

feat(frontend): add job posting template library

What Changed
Added a job posting template library for common freelance job types.
Added template categories to make common job types easier to discover.
Added template search to quickly find relevant job posting templates.
Added support for saving custom job posting templates.
Added pre-filled descriptions and suggested amount ranges when using a template.
Added support for sharing job posting templates with the community.
Integrated templates into the job posting flow so clients can start from an existing template and customize it before publishing.
Kept template values editable to allow clients to adjust descriptions, pricing, and other job details to their specific needs.
Validation
 I referenced the related issue in this PR.
 Contract checks pass (soroban contract build and cargo test in contracts/escrow) if contract code changed.
 Frontend checks/build pass for changed frontend files.
 I included screenshots or short clips for UI changes (or noted N/A).
Additional Notes

This change is scoped to the frontend and is intended to reduce the time clients spend creating recurring or similar job postings.

Templates provide a starting point rather than fixed job postings, so clients can review and customize the suggested descriptions and amount ranges before publishing.

No contract changes are required for this feature.