### PR TITLE
feat: add job similiarity recommendation on detail page

### DIFF
--- a/frontend/app/job/[id]/page.tsx
+++ b/frontend/app/job/[id]/page.tsx
@@ -58,6 +58,7 @@ import type { Job } from "@/lib/types";
 import { useWallet } from "@/lib/wallet-context";
 import { useMeetings } from "@/lib/meetings-context";
 import CertificateDownloadButton from "@/components/CertificateDownloadButton";
+import SimilarJobsSection from "@/components/SimilarJobsSection";
 import { buildCertificateData } from "@/lib/certificate-pdf";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -1569,6 +1570,15 @@ useEffect(() => {
         </>
       )}
 
+      {job && (
+        <SimilarJobsSection
+          job={job}
+          jobId={id}
+          description={description}
+          fiatCurrency={fiatCurrency}
+          fiatRates={fiatRates}
+        />
+      )}
 
       {canTopUp && showTopUpForm && (
         <div className="rounded-lg border border-slate-200 bg-white p-4 space-y-3">

--- a/frontend/components/SimilarJobsSection.tsx
+++ b/frontend/components/SimilarJobsSection.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  X as XIcon,
+  Sparkles,
+  Filter,
+  CircleAlert,
+} from "lucide-react";
+import SectionCard from "@/components/SectionCard";
+import StatusPill from "@/components/StatusPill";
+import TruncatedAddress from "@/components/TruncatedAddress";
+import { formatDeadline, formatXlmWithFiat, type FiatCurrency, type XlmFiatRateCache } from "@/lib/format";
+import { JOB_CATEGORIES } from "@/lib/job-categories";
+import {
+  getSimilarJobs,
+  isMarkedNotInterested,
+  markNotInterested,
+  SIMILARITY_CRITERIA,
+  type ScoredJob,
+  type SimilarityCriteria,
+} from "@/lib/similar-jobs";
+import type { Job } from "@/lib/types";
+
+interface SimilarJobsSectionProps {
+  job: Job;
+  jobId: string;
+  description: string | null;
+  fiatCurrency: FiatCurrency;
+  fiatRates: XlmFiatRateCache | null;
+}
+
+type FilterValue = SimilarityCriteria;
+
+export default function SimilarJobsSection({
+  job,
+  jobId,
+  description,
+  fiatCurrency,
+  fiatRates,
+}: SimilarJobsSectionProps) {
+  const [criteria, setCriteria] = useState<FilterValue>("all");
+  const [results, setResults] = useState<ScoredJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getSimilarJobs(job, jobId, criteria, description || undefined)
+      .then(({ jobs }) => {
+        if (cancelled) return;
+        setResults(jobs);
+        setDismissedIds((prev) => {
+          const next = new Set(prev);
+          for (const item of jobs) {
+            if (isMarkedNotInterested(jobId, String(item.id))) next.add(String(item.id));
+          }
+          return next;
+        });
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load similar jobs.");
+        setResults([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [job, jobId, criteria, description]);
+
+  const handleNotInterested = useCallback(
+    (targetId: string) => {
+      markNotInterested(jobId, targetId);
+      setDismissedIds((prev) => new Set(prev).add(targetId));
+    },
+    [jobId],
+  );
+
+  const handleCriteriaChange = useCallback((next: FilterValue) => {
+    setCriteria(next);
+    setLoading(true);
+    setError(null);
+  }, []);
+
+  const visible = useMemo(
+    () => results.filter((item) => !dismissedIds.has(String(item.id))),
+    [results, dismissedIds],
+  );
+
+  const reasonsLabel = (reasons: SimilarityCriteria[]): string => {
+    const labels: Record<string, string> = {
+      amount: "Amount",
+      category: "Category",
+      description: "Description",
+    };
+    const list = reasons.map((r) => labels[r]).filter(Boolean);
+    return list.length > 0 ? list.join(", ") : "Similar";
+  };
+
+  const renderSkeleton = () => (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="interactive-card h-full animate-pulse rounded-lg border border-slate-200 bg-white p-4"
+        >
+          <div className="h-5 w-28 rounded bg-slate-200" />
+          <div className="mt-3 h-4 w-20 rounded bg-slate-200" />
+          <div className="mt-3 h-4 w-full rounded bg-slate-200" />
+          <div className="mt-4 flex gap-2">
+            <div className="h-8 w-24 rounded-md bg-slate-200" />
+            <div className="h-8 w-24 rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <SectionCard
+      title="Similar Jobs"
+      description="Opportunities matched to this job by category, amount, and description."
+    >
+      <div className="mb-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-700">
+            <Filter className="h-4 w-4" aria-hidden="true" />
+            Match by:
+          </span>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Similarity criteria">
+            {SIMILARITY_CRITERIA.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleCriteriaChange(option.value)}
+                aria-pressed={criteria === option.value}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  criteria === option.value
+                    ? "bg-slate-900 text-white"
+                    : "border border-slate-300 bg-white text-slate-600 hover:bg-slate-50"
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {loading && <>{renderSkeleton()}</>}
+
+      {!loading && error && (
+        <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          <CircleAlert className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && visible.length === 0 && (
+        <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
+          <Sparkles className="mx-auto h-6 w-6 text-slate-400" aria-hidden="true" />
+          <p className="mt-2 font-medium text-slate-700">
+            No similar jobs found
+          </p>
+          <p className="mt-1 text-sm text-slate-500">
+            Try a different match criterion, or check back later for new opportunities.
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && visible.length > 0 && (
+        <ul className="grid list-none gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {visible.map(({ id, job: candidate, score, reasons }) => {
+            const cat = JOB_CATEGORIES.find(
+              (c) => c.id === candidate.category?.toLowerCase() || c.label === candidate.category,
+            );
+            const Icon = cat?.icon;
+            const deadline = formatDeadline(candidate.deadline);
+            return (
+              <li key={id}>
+                <article className="interactive-card flex h-full flex-col rounded-lg border border-slate-200 bg-white p-4">
+                  <div className="mb-2 flex items-start justify-between gap-2">
+                    <h3 className="font-medium text-slate-900">
+                      <Link href={`/job/${id}`} className="hover:underline">
+                        Job #{id}
+                      </Link>
+                    </h3>
+                    <button
+                      type="button"
+                      onClick={() => handleNotInterested(String(id))}
+                      className="shrink-0 rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                      aria-label={`Not interested in Job #${id}`}
+                      title="Not interested"
+                    >
+                      <XIcon className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill status={candidate.status} />
+                    {cat && (
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${cat.colorClass}`}
+                      >
+                        {Icon && <Icon className="h-3.5 w-3.5" aria-hidden="true" />}
+                        {cat.label}
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="mt-2 text-sm font-semibold tabular-nums text-slate-700">
+                    {formatXlmWithFiat(candidate.amount, fiatCurrency, fiatRates?.rates)}
+                  </p>
+
+                  <p className="mt-1 line-clamp-2 text-xs text-slate-600">
+                    {candidate.title ? candidate.title : `Job posted by ${candidate.client}`}
+                  </p>
+
+                  <div className="mt-3 flex items-center gap-2 text-xs text-slate-500">
+                    <span className="inline-flex items-center gap-1">
+                      <Sparkles className="h-3.5 w-3.5 text-emerald-500" aria-hidden="true" />
+                      {Math.round(score * 100)}% match
+                    </span>
+                    {reasons.length > 0 && (
+                      <span className="text-slate-400">• {reasonsLabel(reasons)}</span>
+                    )}
+                  </div>
+
+                  <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-slate-100 pt-2 text-xs text-slate-500">
+                    {deadline && (
+                      <span title={deadline.exact}>
+                        {deadline.isPast ? "Past due" : `Due ${deadline.relative}`}
+                      </span>
+                    )}
+                    <span className="inline-flex items-center gap-1">
+                      <TruncatedAddress address={candidate.client} chars={4} />
+                    </span>
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -286,6 +286,31 @@ export async function getJob(jobId: string): Promise<Job | null> {
   return (response.data as Job) ?? null;
 }
 
+export async function getJobsBatch(start: string, limit: number): Promise<Job[]> {
+  const response = await callContract(
+    getActiveContractId(),
+    "get_jobs_batch",
+    [
+      nativeToScVal(start, { type: "u64" }),
+      nativeToScVal(limit, { type: "u32" }),
+    ],
+    { readOnly: true },
+  );
+  return (response.data as Job[]) ?? [];
+}
+
+export async function getJobsByCategory(category: string): Promise<number[]> {
+  const response = await callContract(
+    getActiveContractId(),
+    "get_jobs_by_category",
+    [nativeToScVal(category, { type: "symbol" })],
+    { readOnly: true },
+  );
+  const data = response.data as number[] | string[] | undefined;
+  if (!data) return [];
+  return data.map((id) => Number(id));
+}
+
 export async function getJobCount(): Promise<number> {
   const response = await callContract(
     getActiveContractId(),

--- a/frontend/lib/similar-jobs.ts
+++ b/frontend/lib/similar-jobs.ts
@@ -1,0 +1,320 @@
+import { getJob, getJobsBatch, getJobsByCategory } from "@/lib/contract";
+import type { Job } from "@/lib/types";
+
+export type SimilarityCriteria = "amount" | "category" | "description" | "all";
+
+export interface ScoredJob {
+  id: number;
+  job: Job;
+  score: number;
+  reasons: SimilarityCriteria[];
+}
+
+export interface SimilarJobsResult {
+  jobs: ScoredJob[];
+  fromCache: boolean;
+}
+
+const CACHE_KEY = "stellarwork:similar-jobs-cache";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const NOT_INTERESTED_KEY = "stellarwork:similar-jobs-not-interested";
+const MAX_CANDIDATES = 60;
+const DEFAULT_LIMIT = 6;
+const MAX_BATCH = 120;
+
+/** Frontend category id -> on-chain JobCategory symbol (contract only has a subset). */
+const ON_CHAIN_CATEGORY: Record<string, string> = {
+  development: "Development",
+  design: "Design",
+  writing: "Writing",
+  marketing: "Marketing",
+  data: "Data",
+  consulting: "Other",
+  other: "Other",
+  devops: "DevOps",
+};
+
+interface CacheEntry {
+  key: string;
+  jobs: ScoredJob[];
+  at: number;
+}
+
+interface NotInterestedEntry {
+  jobId: number;
+  sourceJobId: number;
+  at: number;
+}
+
+function getCacheKey(sourceJobId: string, criteria: SimilarityCriteria): string {
+  return `${sourceJobId}:${criteria}`;
+}
+
+function readCache<T>(key: string, ttl: number): T | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as { at: number; value: T };
+    if (Date.now() - entry.at > ttl) {
+      localStorage.removeItem(key);
+      return null;
+    }
+    return entry.value;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(key, JSON.stringify({ at: Date.now(), value }));
+  } catch {
+    // Storage full or unavailable — skip caching.
+  }
+}
+
+export function getSimilarJobsCache(
+  sourceJobId: string,
+  criteria: SimilarityCriteria,
+): SimilarJobsResult | null {
+  const cached = readCache<CacheEntry>(CACHE_KEY, CACHE_TTL_MS);
+  if (cached && cached.key === getCacheKey(sourceJobId, criteria)) {
+    return { jobs: cached.jobs, fromCache: true };
+  }
+  return null;
+}
+
+export function setSimilarJobsCache(
+  sourceJobId: string,
+  criteria: SimilarityCriteria,
+  jobs: ScoredJob[],
+): void {
+  const entry: CacheEntry = {
+    key: getCacheKey(sourceJobId, criteria),
+    jobs,
+    at: Date.now(),
+  };
+  writeCache(CACHE_KEY, entry);
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 2 && !STOP_WORDS.has(word));
+}
+
+const STOP_WORDS = new Set([
+  "the", "and", "for", "with", "that", "this", "your", "our", "are",
+  "you", "will", "can", "have", "from", "please", "nbsp", "about",
+  "into", "has", "its", "all", "was", "but", "not", "what", "when",
+  "them", "than", "then", "they", "their", "there", "these", "those",
+]);
+
+function amountRatio(aAmount: string, bAmount: string): number {
+  const a = BigInt(aAmount || "0");
+  const b = BigInt(bAmount || "0");
+  if (a <= 0n || b <= 0n) return 0;
+  if (a > b) return Number((b * 10000n) / a) / 10000;
+  return Number((a * 10000n) / b) / 10000;
+}
+
+export function scoreSimilarity(
+  source: Job,
+  candidate: Job,
+  sourceDescription: string,
+  candidateDescription: string,
+): { score: number; reasons: SimilarityCriteria[] } {
+  let score = 0;
+  const reasons: SimilarityCriteria[] = [];
+
+  const sourceCategory = (source.category || "").toLowerCase().trim();
+  const candidateCategory = (candidate.category || "").toLowerCase().trim();
+
+  if (sourceCategory && candidateCategory && sourceCategory === candidateCategory) {
+    score += 0.5;
+    reasons.push("category");
+  }
+
+  const ratio = amountRatio(source.amount, candidate.amount);
+  if (ratio >= 0.5) {
+    score += ratio * 0.25;
+    reasons.push("amount");
+  }
+
+  const sourceTokens = tokenize(sourceDescription);
+  const candidateTokens = tokenize(candidateDescription);
+  if (sourceTokens.length > 0 && candidateTokens.length > 0) {
+    const sourceSet = new Set(sourceTokens);
+    const candidateSet = new Set(candidateTokens);
+    let overlap = 0;
+    for (const token of candidateSet) {
+      if (sourceSet.has(token)) overlap++;
+    }
+    const descScore = overlap / Math.min(sourceSet.size, candidateSet.size);
+    if (descScore > 0) {
+      score += Math.min(1, descScore) * 0.25;
+      reasons.push("description");
+    }
+  }
+
+  const sourceTitle = (source.title || "").toLowerCase().trim();
+  const candidateTitle = (candidate.title || "").toLowerCase().trim();
+  if (sourceTitle && candidateTitle && sourceTitle === candidateTitle) {
+    score += 0.1;
+  }
+
+  return { score: Math.min(1, score), reasons };
+}
+
+function getNotInterestedEntries(): NotInterestedEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(NOT_INTERESTED_KEY);
+    if (!raw) return [];
+    const entries = JSON.parse(raw) as NotInterestedEntry[];
+    return Array.isArray(entries) ? entries : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isMarkedNotInterested(sourceJobId: string, jobId: string): boolean {
+  return getNotInterestedEntries().some(
+    (entry) => entry.sourceJobId === Number(sourceJobId) && entry.jobId === Number(jobId),
+  );
+}
+
+export function markNotInterested(sourceJobId: string, jobId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const entries = getNotInterestedEntries();
+    entries.push({ jobId: Number(jobId), sourceJobId: Number(sourceJobId), at: Date.now() });
+    localStorage.setItem(NOT_INTERESTED_KEY, JSON.stringify(entries));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function readLocalDescription(hash: string): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(`job-desc:${hash}`) || "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Fetch candidate open jobs, preferring same-category jobs (via the on-chain
+ * `get_jobs_by_category` helper) and falling back to a positional batch scan.
+ */
+async function collectCandidates(
+  sourceJob: Job,
+  sourceId: string,
+  criteria: SimilarityCriteria,
+): Promise<ScoredJob[]> {
+  const candidates: ScoredJob[] = [];
+  const seenHashes = new Set<string>([sourceJob.description_hash]);
+
+  const sourceCategory = (sourceJob.category || "").toLowerCase().trim();
+
+  if ((criteria === "all" || criteria === "category") && sourceCategory) {
+    const onChain = ON_CHAIN_CATEGORY[sourceCategory];
+    if (onChain) {
+      try {
+        const categoryIds = await getJobsByCategory(onChain);
+        const limited = categoryIds
+          .map((id) => String(id))
+          .filter((id) => id !== sourceId)
+          .slice(0, MAX_CANDIDATES);
+        for (const jobId of limited) {
+          try {
+            const job = await getJob(jobId);
+            if (job && job.status === "Open" && !seenHashes.has(job.description_hash)) {
+              seenHashes.add(job.description_hash);
+              candidates.push({ id: Number(jobId), job, score: 0, reasons: [] });
+            }
+          } catch {
+            // Skip unavailable jobs.
+          }
+        }
+      } catch {
+        // Fall through to batch scan.
+      }
+    }
+  }
+
+  if (candidates.length < MAX_CANDIDATES) {
+    try {
+      const needed = MAX_CANDIDATES - candidates.length;
+      const size = Math.min(MAX_BATCH, Math.max(needed, 40));
+      const batch = await getJobsBatch("1", size);
+      batch.forEach((job, index) => {
+        if (candidates.length >= MAX_CANDIDATES) return;
+        if (seenHashes.has(job.description_hash)) return;
+        seenHashes.add(job.description_hash);
+        if (job.status === "Open") {
+          candidates.push({ id: index + 1, job, score: 0, reasons: [] });
+        }
+      });
+    } catch {
+      // Batch scan failed — use whatever category matches we found.
+    }
+  }
+
+  return candidates;
+}
+
+export async function getSimilarJobs(
+  sourceJob: Job,
+  sourceId: string,
+  criteria: SimilarityCriteria = "all",
+  description?: string,
+  limit: number = DEFAULT_LIMIT,
+): Promise<SimilarJobsResult> {
+  const cached = getSimilarJobsCache(sourceId, criteria);
+  if (cached) return cached;
+
+  const candidates = await collectCandidates(sourceJob, sourceId, criteria);
+  const sourceDescription = description || readLocalDescription(sourceJob.description_hash);
+
+  const scored: ScoredJob[] = [];
+  for (const candidate of candidates) {
+    if (String(candidate.id) === sourceId) continue;
+    if (isMarkedNotInterested(sourceId, String(candidate.id))) continue;
+    if (!candidate.job.title && !candidate.job.category) continue;
+
+    const candidateDescription = readLocalDescription(candidate.job.description_hash);
+    const { score, reasons } = scoreSimilarity(
+      sourceJob,
+      candidate.job,
+      sourceDescription,
+      candidateDescription,
+    );
+
+    if (criteria === "amount" && !reasons.includes("amount")) continue;
+    if (criteria === "category" && !reasons.includes("category")) continue;
+    if (criteria === "description" && !reasons.includes("description")) continue;
+    if (score <= 0) continue;
+
+    scored.push({ id: candidate.id, job: candidate.job, score, reasons });
+  }
+
+  scored.sort((a, b) => b.score - a.score || a.id - b.id);
+
+  const results = scored.slice(0, limit);
+  setSimilarJobsCache(sourceId, criteria, results);
+  return { jobs: results, fromCache: false };
+}
+
+export const SIMILARITY_CRITERIA: { value: SimilarityCriteria; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "category", label: "Category" },
+  { value: "amount", label: "Amount" },
+  { value: "description", label: "Description" },
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,9 +69,8 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^3.2.4",
-    "vitest-axe": "^0.1.0"
-    "vite": "^5.4.21",
-    "vitest": "^3.2.4"
+    "vitest-axe": "^0.1.0",
+    "vite": "^5.4.21"
   },
   "overrides": {
     "axios": "^1.18.0",


### PR DESCRIPTION
## [FE-169] Add job similarity recommendations on detail page

### Summary

Adds a **"Similar Jobs"** section to the job detail page so freelancers can discover relevant opportunities after viewing a job. Recommendations are computed from job attributes (category, amount, and description) and can be filtered by match criterion.

### Problem

Freelancers miss relevant opportunities after viewing a job — there was no way to discover similar work from the detail page.

### Solution

- **Similarity scoring** — Each candidate job is scored across four signals:
  - Category match (`+0.5`)
  - Amount proximity (`+0 → +0.25`)
  - Description keyword overlap (`+0 → +0.25`)
  - Exact title match (`+0.1`)
- **"Similar Jobs" section** on the job detail page renders the top matched jobs as cards (status pill, category badge, amount, title, match %, deadline, and client).
- **Filter by criteria** — A "Match by:" control (All / Category / Amount / Description) lets freelancers narrow recommendations.
- **Caching** — Recommendations are cached in `localStorage` with a 5-minute TTL (keyed by `jobId:criteria`) to reduce redundant RPC calls, following the existing cache patterns in the app.
- **"Not interested" feedback** — Each card has a dismiss button that persists the dismissal and excludes it from future recommendations for that source job.

### Files changed

| File | Change |
| --- | --- |
| `frontend/lib/similar-jobs.ts` | **New.** Similarity scoring, candidate collection (on-chain `get_jobs_by_category` + batch scan), caching, and "not interested" persistence. |
| `frontend/components/SimilarJobsSection.tsx` | **New.** The "Similar Jobs" UI section: criteria filter, job cards, skeleton/empty/error states, and dismiss buttons. |
| `frontend/app/job/[id]/page.tsx` | Renders `<SimilarJobsSection>` after the main job content. |
| `frontend/lib/contract.ts` | Added `getJobsByCategory()` and `getJobsBatch()` RPC wrappers. |

### How it works

1. On page load, the section fetches candidate open jobs — preferring same-category jobs via the existing on-chain `get_jobs_by_category` helper, falling back to a positional batch scan.
2. Each candidate is scored and sorted by similarity, filtered by the selected criterion.
3. Results are cached per `jobId:criteria`; dismissals are persisted per source job and filtered out on subsequent fetches.

### Verification

- `tsc --noEmit`: no type errors in any changed/new files.
- `eslint`: all new/modified files pass cleanly.

### Notes

- Pre-existing type errors in `app/dashboard/page.tsx` and `app/layout.tsx` are left untouched as they are unrelated to this change.
- `frontend/package.json` had a pre-existing JSON syntax error (missing comma and a duplicate `vitest` key) that blocked install/build/typecheck. Applied a minimal, purely structural one-line fix as a build enabler — no dependency changes were made.
- Unrelated `package-lock.json` regeneration churn produced during local dependency install was reverted.


Closes #806 