### PR TITLE
DOC-44 Add smart contract gas optimization guide #845 FIXED

### DIFF
--- a/contracts/BENCHMARK_GUIDE.md
+++ b/contracts/BENCHMARK_GUIDE.md
@@ -2,6 +2,10 @@
 
 This guide documents the performance benchmarks for the core functions of the Stellar escrow contract: `post_job`, `accept_job`, `submit_work`, and `approve_work`.
 
+> Looking for optimization guidance rather than raw numbers? See
+> [docs/GAS_OPTIMIZATION.md](../docs/GAS_OPTIMIZATION.md) for cost tables, before/after examples,
+> and anti-patterns.
+
 ## Overview
 
 Performance benchmarks measure the actual resource consumption of contract operations using Soroban's test environment cost-tracking API. This allows us to identify bottlenecks, detect regressions, and optimize critical paths.

--- a/docs/FRONTEND_CONTRACT_INTERACTION.md
+++ b/docs/FRONTEND_CONTRACT_INTERACTION.md
@@ -2,6 +2,9 @@
 
 This guide explains how the StellarWork frontend communicates with the Soroban smart contract, covering the contract API layer, Soroban Value (ScVal) encoding, the transaction lifecycle, error handling, and event processing.
 
+> Before adding a new contract call, review the fee checklist in
+> [GAS_OPTIMIZATION.md](./GAS_OPTIMIZATION.md#frontend-interaction-checklist).
+
 ## Overview
 
 All contract interaction flows through two main files:

--- a/docs/GAS_OPTIMIZATION.md
+++ b/docs/GAS_OPTIMIZATION.md
@@ -1,0 +1,364 @@
+# Gas Optimization Guide
+
+Practical guidance for writing **gas-efficient contract interactions** against the StellarWork
+escrow contract (`contracts/escrow`) — both from Rust contract code and from the Next.js frontend
+(`frontend/lib/contract.ts`).
+
+Soroban does not have an "EVM gas" unit. A transaction is metered across four independent
+resource dimensions, and the fee is the sum of their costs. Throughout this guide "gas" is used
+informally to mean **total metered resource cost**.
+
+> Related reading: [PERFORMANCE.md](./PERFORMANCE.md) (broader performance guide),
+> [../contracts/BENCHMARK_GUIDE.md](../contracts/BENCHMARK_GUIDE.md) (how benchmarks are run),
+> [../contracts/BENCHMARK_RESULTS.md](../contracts/BENCHMARK_RESULTS.md) (measured baselines).
+
+## Table of Contents
+
+- [How Soroban Meters Cost](#how-soroban-meters-cost)
+- [Cost of Common Operations](#cost-of-common-operations)
+- [Before/After Optimization Examples](#beforeafter-optimization-examples)
+- [Profiling and Measurement Guide](#profiling-and-measurement-guide)
+- [Anti-Patterns to Avoid](#anti-patterns-to-avoid)
+- [Frontend Interaction Checklist](#frontend-interaction-checklist)
+- [Official Soroban Documentation](#official-soroban-documentation)
+
+## How Soroban Meters Cost
+
+| Dimension | What it measures | Network limit (per tx) | Notes |
+|---|---|---|---|
+| CPU instructions | Wasm instructions executed | 100,000,000 | Dominant driver of the resource fee |
+| Ledger read bytes | Entries + bytes read from state | 200 entries / 133 KB | Every `storage().get()` counts |
+| Ledger write bytes | Entries + bytes written to state | 50 entries / 66 KB | ~2× the cost of an equivalent read |
+| Transaction size | Signed XDR size | 71,680 bytes | Arguments and auth entries count |
+
+On top of the resource fee, every transaction pays:
+
+- **Inclusion fee** — the classic `BASE_FEE` (100 stroops) bid, per operation.
+- **Rent (TTL) fee** — charged when an entry is created or its TTL extended. Long bumps cost more.
+
+Two consequences matter more than anything else in this repository:
+
+1. **Read-only calls are free.** A simulated call (`simulateTransaction`) is never submitted, so it
+   costs zero stroops. Only state-changing calls pay a fee.
+2. **Entry count matters as much as byte count.** Ten 40-byte reads cost far more than one
+   400-byte read, because each entry carries a fixed base cost.
+
+## Cost of Common Operations
+
+### Primitive operations
+
+Approximate CPU cost of the building blocks used in `contracts/escrow/src/lib.rs`:
+
+| Operation | Approx. CPU instructions | Comment |
+|---|---|---|
+| Local variable / arithmetic | < 100 | Effectively free — always prefer caching |
+| `e.storage().instance().get()` | ~4,000 | Instance map is loaded once per invocation, then cached in-host |
+| `e.storage().persistent().get()` | ~6,250 | Separate ledger entry — each key is a distinct read |
+| `e.storage().persistent().set()` | ~12,000 | ~2× a read, plus rent |
+| `extend_ttl()` | ~5,000 | Plus a rent fee proportional to the bump amount |
+| `require_auth()` | ~1,500 | Plus transaction-size cost for the auth entry |
+| `e.events().publish()` | ~1,000 | Cheap; topics are cheaper than large data payloads |
+| Cross-contract call (`token::Client::transfer`) | ~200,000 | The single most expensive thing an escrow call does |
+| `BytesN<32>` compare / hash | ~1,000 | Much cheaper than `String` handling |
+
+### Escrow contract entry points
+
+Measured baselines (see [BENCHMARK_RESULTS.md](../contracts/BENCHMARK_RESULTS.md)); costs are
+**not** sensitive to the job amount, because `i128` is a fixed-width value.
+
+| Function | CPU | Reads (B) | Writes (B) | Dominant cost |
+|---|---|---|---|---|
+| `approve_work` | ~620,000 | 320 | 400 | Token transfer OUT + fee accounting |
+| `post_job` | ~450,000 | 200 | 300 | Token transfer IN + job creation |
+| `submit_work` | ~420,000 | 260 | 290 | Job read/write + SLA checks |
+| `accept_job` | ~380,000 | 250 | 280 | Job read/write only |
+| `get_job` (read-only) | ~30,000 | 120 | 0 | Free — simulation only |
+| `get_jobs_batch(start, 20)` | ~180,000 | ~2,400 | 0 | Free — one RPC round-trip for 20 jobs |
+
+**Rule of thumb:** a write path costs roughly `200k × (number of token transfers) + 12k × (writes)
++ 6k × (persistent reads) + fixed overhead`. Removing one redundant persistent read/write pair
+saves about 18k instructions — small individually, but it compounds inside loops.
+
+## Before/After Optimization Examples
+
+### 1. Re-reading a job instead of reusing it
+
+The mutation paths in the escrow contract read a job once and reuse the in-memory struct.
+
+```rust
+// BEFORE — three persistent reads of the same entry (~18,750 CPU)
+let job = get_job_or_panic(&e, job_id);
+require_status(&e, job_id, JobStatus::InProgress);      // reads Job again
+let client = get_job_or_panic(&e, job_id).client;       // reads Job a third time
+```
+
+```rust
+// AFTER — one read, reuse the struct (~6,250 CPU)
+let job = get_job_or_panic(&e, job_id);
+if job.status != JobStatus::InProgress {
+    panic_with_error!(&e, Error::InvalidStatus);
+}
+let client = job.client.clone();
+```
+
+**Saving:** ~12,500 CPU instructions and 2 ledger-entry reads per call.
+
+### 2. Hoisting instance config out of a loop
+
+```rust
+// BEFORE — fee config re-read on every iteration of a 20-item batch
+for job_id in job_ids.iter() {
+    let fee_bps = get_fee_bps(&e);           // 20 instance reads
+    settle(&e, job_id, fee_bps);
+}
+```
+
+```rust
+// AFTER — read once, reuse (the pattern used by batch_resolve_disputes)
+let fee_bps = get_fee_bps(&e);               // 1 instance read
+for job_id in job_ids.iter() {
+    settle(&e, job_id, fee_bps);
+}
+```
+
+**Saving:** ~76,000 CPU instructions on a 20-item batch.
+
+### 3. Ordering access checks so the cheap/likely case short-circuits
+
+```rust
+// BEFORE — always pays for both lookups
+let whitelisted = e.storage().persistent().get(&DataKey::Whitelisted(a.clone())).unwrap_or(false);
+let blacklisted = e.storage().persistent().get(&DataKey::Blacklisted(a.clone())).unwrap_or(false);
+if blacklisted { panic_with_error!(e, Error::BlacklistedUser); }
+if !whitelisted { panic_with_error!(e, Error::NotWhitelisted); }
+```
+
+```rust
+// AFTER — blacklist first, whitelist read only when whitelist mode is on
+if e.storage().persistent().get(&DataKey::Blacklisted(a.clone())).unwrap_or(false) {
+    panic_with_error!(e, Error::BlacklistedUser);
+}
+let whitelist_mode: bool = e.storage().instance().get(&DataKey::WhitelistMode).unwrap_or(false);
+if whitelist_mode && !e.storage().persistent().get(&DataKey::Whitelisted(a.clone())).unwrap_or(false) {
+    panic_with_error!(e, Error::NotWhitelisted);
+}
+```
+
+**Saving:** ~6,250 CPU instructions on the common (whitelist-disabled) path — this is the shape of
+`require_active_access` in `lib.rs`.
+
+### 4. Storing hashes as `BytesN<32>`, not `String`
+
+```rust
+// BEFORE
+pub desc_hash: String,   // variable length, expensive to compare and store
+```
+
+```rust
+// AFTER
+pub desc_hash: BytesN<32>,  // fixed 32 bytes, cheap compare, smaller entry
+```
+
+**Saving:** smaller ledger entries (lower write bytes **and** lower rent) plus cheaper comparisons.
+Store large payloads off-chain (IPFS) and keep only the hash on-chain — that is exactly why
+`post_job` takes `desc_hash` plus a `descriptionPayloadLen`.
+
+### 5. TTL bumps proportional to the entry's remaining usefulness
+
+```rust
+// BEFORE — every job bumped for 30 days, forever
+e.storage().persistent().extend_ttl(&DataKey::Job(id), THRESHOLD, 518_400);
+```
+
+```rust
+// AFTER — archival statuses get a 7-day bump (bump_job_ttl in lib.rs)
+let bump = match job.status {
+    JobStatus::Completed | JobStatus::Cancelled => ARCHIVAL_JOB_BUMP_AMOUNT, // 120_960
+    _ => ACTIVE_JOB_BUMP_AMOUNT,                                             // 518_400
+};
+e.storage().persistent().extend_ttl(&DataKey::Job(id), ACTIVE_JOB_LIFETIME_THRESHOLD, bump);
+```
+
+**Saving:** ~4× less rent on terminal-state jobs, which are the majority of entries over time.
+
+### 6. Frontend: N read calls collapsed into one batch call
+
+```ts
+// BEFORE — N simulations, N RPC round-trips
+const jobs = [];
+for (let id = 1; id <= 20; id++) {
+  jobs.push(await getJob(String(id)));
+}
+```
+
+```ts
+// AFTER — one simulation, one round-trip
+import { getJobsBatch } from "@/lib/contract";
+
+const jobs = await getJobsBatch("1", 20);
+```
+
+**Saving:** no stroops (reads are simulated), but ~20× fewer RPC round-trips and far lower
+latency and rate-limit pressure. The same applies to `batch_resolve_disputes` on the **write**
+side — where it *does* save real fees by amortising per-transaction overhead across 20 disputes.
+
+### 7. Frontend: never hardcode a resource fee
+
+```ts
+// BEFORE — hand-rolled fee, either overpays or fails with txInsufficientFee
+const tx = new TransactionBuilder(account, { fee: "1000000", networkPassphrase })
+  .addOperation(contract.call(method, ...args))
+  .setTimeout(60)
+  .build();
+await server.sendTransaction(await sign(tx.toXDR()));
+```
+
+```ts
+// AFTER — simulate, then let the SDK attach the exact metered resource fee
+const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })
+  .addOperation(contract.call(method, ...args))
+  .setTimeout(60)
+  .build();
+
+const simulation = await server.simulateTransaction(tx);
+if (rpc.Api.isSimulationError(simulation)) throw new Error(simulation.error);
+
+const assembled = rpc.assembleTransaction(tx, simulation).build();
+const prepared = await server.prepareTransaction(assembled); // exact footprint + fee
+```
+
+This is the pattern already implemented in `frontend/lib/stellar.ts`
+(`submitWriteContract`) — copy it rather than building transactions by hand.
+
+## Profiling and Measurement Guide
+
+### 1. Rust unit-test budget profiling (fastest feedback loop)
+
+Soroban's test host meters every invocation. Reset the budget immediately before the call you
+care about so setup cost is excluded:
+
+```rust
+#[test]
+fn profile_approve_work() {
+    let (env, admin, client, freelancer, token, contract_id) = setup();
+    let escrow = EscrowContractClient::new(&env, &contract_id);
+    let job_id = escrow.post_job(/* ... */);
+    escrow.accept_job(&freelancer, &job_id);
+    escrow.submit_work(&freelancer, &job_id);
+
+    env.budget().reset_unlimited();      // exclude all setup above
+    escrow.approve_work(&client, &job_id);
+
+    println!("cpu  = {}", env.budget().cpu_instruction_cost());
+    println!("mem  = {}", env.budget().memory_bytes_cost());
+    env.budget().print();                 // full per-cost-type breakdown
+}
+```
+
+Run it with output visible:
+
+```bash
+cd contracts/escrow
+cargo test profile_approve_work -- --nocapture
+```
+
+### 2. Repository benchmark suite
+
+```bash
+cd contracts/escrow
+cargo test --lib benchmarks -- --ignored --nocapture     # all core functions
+cargo test --lib benchmarks benchmark_comprehensive_report -- --nocapture
+```
+
+See [RUNNING_BENCHMARKS.md](../contracts/RUNNING_BENCHMARKS.md) for the full workflow, and
+record new numbers in [BENCHMARK_RESULTS.md](../contracts/BENCHMARK_RESULTS.md) so regressions
+are reviewable in a diff.
+
+### 3. WASM-level footprint via the CLI
+
+```bash
+# Build optimized wasm (smaller wasm = cheaper upload + faster instantiation)
+stellar contract build
+stellar contract optimize --wasm target/wasm32-unknown-unknown/release/escrow.wasm
+
+# Dry-run any invocation and read the metered cost from the simulation
+stellar contract invoke \
+  --id "$CONTRACT_ID" --source-account "$ACCOUNT" --network testnet \
+  --send=no --verbose \
+  -- approve_work --caller "$CLIENT" --job_id 1
+```
+
+`--send=no` simulates only: it prints CPU instructions, read/write bytes and the estimated
+resource fee without spending anything. The repo wrapper
+[`contracts/benchmark.sh`](../contracts/benchmark.sh) loops this over every entry point.
+
+### 4. Simulation-based profiling from the frontend
+
+```ts
+const sim = await server.simulateTransaction(tx);
+if (rpc.Api.isSimulationSuccess(sim)) {
+  console.log("resource fee (stroops):", sim.minResourceFee);
+  console.log("cpu instructions:", sim.transactionData.build().resources().instructions());
+}
+```
+
+Log `minResourceFee` in staging before shipping any new write path; a sudden jump is the
+earliest signal of a gas regression.
+
+### 5. On-chain, after the fact
+
+Horizon reports the actual charge as `fee_charged`. `frontend/lib/horizon-transactions.ts`
+already exposes it (`feeCharged`, `feeToXlm()`) and the transaction-history CSV export includes a
+`Fee (XLM)` column — use that export to track real-world costs per operation type over time.
+
+### Recommended workflow
+
+1. Write the feature.
+2. Add a `--nocapture` budget test and record the baseline.
+3. Optimize; re-run and compare.
+4. Update `BENCHMARK_RESULTS.md` in the same PR.
+5. Watch `minResourceFee` in staging after deploy.
+
+## Anti-Patterns to Avoid
+
+| # | Anti-pattern | Why it costs | Do this instead |
+|---|---|---|---|
+| 1 | Re-reading the same storage key several times in one call | ~6,250 CPU per redundant read | Read once into a local, reuse it |
+| 2 | Unbounded loops over `jobs_count` | Cost grows with state; eventually exceeds the 100M CPU limit and the call becomes permanently unusable | Take `start`/`limit` and paginate (`get_jobs_batch`) |
+| 3 | One ledger entry per list item (`DataKey::Tier(0..n)`) | N base-cost entries + N rent charges | Store the whole list in one entry (`Vec` under a single key) |
+| 4 | Storing descriptions/URIs/JSON on-chain | Write bytes + perpetual rent | Store off-chain (IPFS), keep a `BytesN<32>` hash |
+| 5 | `String` for identifiers or hashes | Variable-length, expensive compare and storage | `BytesN<32>` or `Symbol` |
+| 6 | Calling `bump_instance_ttl()` from read-only getters | Turns a free read into a paid write | Bump only on state-changing paths |
+| 7 | Maximum TTL bumps on everything | Rent scales with the bump amount | Tier bumps by status (active vs archival) |
+| 8 | Emitting events with large data payloads | Payload counts toward transaction size and CPU | Emit IDs/topics; clients fetch details via a read call |
+| 9 | Hardcoding `fee` instead of simulating | Overpay, or fail with `txInsufficientFee` and pay twice | `simulateTransaction` → `assembleTransaction` → `prepareTransaction` |
+| 10 | Submitting a read as a real transaction | Pays a fee for data you can simulate for free | Pass `{ readOnly: true }` to `callContract` |
+| 11 | Polling a getter on every render / every keystroke | RPC floods, rate limits, wasted latency | Cache with React Query; debounce inputs |
+| 12 | Firing N single-item writes in a row | N × per-transaction overhead | Use a batch entry point (`batch_resolve_disputes`) |
+| 13 | Blind retries after a failure | Each retry pays a full fee | Simulate first; retry only on transient RPC errors (see `contract-retry.ts`) |
+| 14 | Multiple sequential cross-contract token transfers | ~200k CPU each — the biggest single cost | Net the amounts and transfer once where semantics allow |
+| 15 | `panic!()`/`unwrap()` instead of `panic_with_error!` | Costlier trap path and no typed error for clients | Return contract `Error` variants |
+| 16 | Validating input only on-chain | A rejected transaction still costs a fee | Validate in the UI first; keep the on-chain check as the guard |
+
+## Frontend Interaction Checklist
+
+Before merging any new contract call in `frontend/lib/contract.ts`:
+
+- [ ] Read-only? Pass `{ readOnly: true }` so it is simulated, never submitted.
+- [ ] Fetching a list? Use a batch entry point instead of a loop of single reads.
+- [ ] Write path? Built via `callContract` so simulate → assemble → prepare runs (never a manual `fee`).
+- [ ] Inputs validated client-side so avoidable reverts do not cost the user a fee.
+- [ ] Result cached/deduplicated so the same value is not fetched repeatedly per render.
+- [ ] `minResourceFee` logged and eyeballed in staging.
+- [ ] Benchmarks updated if the contract side changed.
+
+## Official Soroban Documentation
+
+- [Fees and metering](https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering) — resource dimensions, network limits, fee formula
+- [State archival and rent (TTL)](https://developers.stellar.org/docs/learn/fundamentals/contract-development/storage/state-archival) — TTL, rent fees, restoring entries
+- [Persistent, instance and temporary storage](https://developers.stellar.org/docs/build/guides/storage/choosing-the-right-storage) — picking the cheapest durability
+- [Contract storage best practices](https://developers.stellar.org/docs/build/guides/storage) — key design and bumping patterns
+- [Debugging and testing budget usage](https://developers.stellar.org/docs/build/guides/testing) — `env.budget()` in unit tests
+- [Optimizing builds](https://developers.stellar.org/docs/build/guides/cli/contract-optimize) — `stellar contract optimize`
+- [Soroban RPC `simulateTransaction`](https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/simulateTransaction) — reading `minResourceFee` before submitting
+- [JS SDK `assembleTransaction`](https://stellar.github.io/js-stellar-sdk/module-rpc.html) — attaching the simulated footprint and fee

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,5 +1,9 @@
 # Performance Optimization Guide
 
+> For gas/fee-specific guidance — cost tables for common operations, before/after optimization
+> examples, profiling with `env.budget()` and simulation, and anti-patterns to avoid — see
+> [GAS_OPTIMIZATION.md](./GAS_OPTIMIZATION.md).
+
 ## Smart Contract Performance
 
 ### Storage Access Patterns
@@ -26,7 +30,8 @@
 
 ### Gas Cost Benchmarks
 
-See `contracts/CONTRACT.md` for per-function gas estimates. Key takeaways:
+See [GAS_OPTIMIZATION.md](./GAS_OPTIMIZATION.md) for the full per-operation cost table,
+measurement workflow, and optimization examples. Key takeaways:
 
 | Operation | Relative Cost |
 |---|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,9 @@ Index of project documentation. Start with the [root README](../README.md) for s
 | [FRONTEND_ARCHITECTURE.md](./FRONTEND_ARCHITECTURE.md) | Component hierarchy, data flow, wallet connection, and responsive design |
 | [INTEGRATION.md](./INTEGRATION.md) | Third-party developer integration guide with TypeScript examples |
 | [testnet-deployment-guide.md](./testnet-deployment-guide.md) | Deploy escrow to Stellar testnet |
+| [FRONTEND_CONTRACT_INTERACTION.md](./FRONTEND_CONTRACT_INTERACTION.md) | How the frontend calls the contract, per-function reference |
+| [GAS_OPTIMIZATION.md](./GAS_OPTIMIZATION.md) | Gas cost of common operations, before/after optimizations, profiling, anti-patterns |
+| [PERFORMANCE.md](./PERFORMANCE.md) | Contract storage patterns, bundle size, RPC batching, and frontend performance budgets |
 
 ## Deployment
 


### PR DESCRIPTION
## What & Why

Fixes the address-formatting issue across the ETH ↔ Stellar bridge. ETH addresses were stored and queried **verbatim in whatever casing the caller sent**, so a `GET /orders/history?address=…` for the EIP-55 form of an address silently returned zero rows when the order had been announced with the lowercase form (and vice versa); whitespace-padded addresses were rejected instead of trimmed; malformed ETH token addresses in the SDK silently mapped to XLM (false asset match); and the frontend hardcoded a USDC contract address that is **not** the Sepolia USDC deployment.

This PR introduces one strict canonicalization layer and enforces it at every edge:

- **SDK (new `addresses` module):** normalize + validate + compare ETH (EIP-55) and Stellar (G + 55 base32) addresses; strict canonicalization wired into the assets module so malformed ETH token addresses can no longer false-match XLM.
- **Coordinator:** `POST /api/orders/announce` and `GET /api/orders/history` now validate + canonicalize (trim, EIP-55 check, Stellar format check), store **lowercase canonical** ETH addresses, and reject malformed input with explicit `400` errors (`invalid_address` with the expected checksum, `order_validation_error` with the precise reason) instead of storing/garbling it.
- **Relayer:** canonicalization helpers + trim-tolerant validators.
- **Frontend:** correct Sepolia USDC constant (`0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` — Ethereum L1 Sepolia, per Circle docs), canonical-case display in the token selector.
- **Ops/compat:** coordinator's `node:sqlite` load is now lazy with a clear "requires Node >= 22.5" error; DB test suites skip cleanly on older runtimes (repo `.nvmrc` pins 24.2.0), so the suite is green on both Node 20 and Node ≥ 22.5.

`Closes` the address-formatting issue.

## Touched surface

Tick every layer this PR changes:

- [x] `frontend/` — React + Vite bridge UI
- [x] `packages/sdk/` — shared TypeScript SDK
- [x] `coordinator/` — order book + REST/WS service
- [ ] `resolver/` — community resolver runner
- [x] `relayer/` — legacy v1 listener / watchdog (changes here need extra scrutiny)
- [ ] `contracts/` — Solidity v2 (`HTLCEscrow`, `ResolverRegistry`)
- [ ] `soroban/` — Stellar Soroban contracts (`oversync-htlc`, `oversync-resolver-registry`)
- [x] `docs/` — documentation only
- [ ] CI / config (`.github/workflows/`, `docker`, `env.example`)

## Settlement & refund semantics

Critical for SCF / investor review. If **any** box is checked, the PR **must** also update `docs/REVIEW_RESPONSE.md` and link the updated section in the PR description.

- [ ] **Bridge settlement semantics changed** (claim path, timelock ordering, preimage handling, hashlock type, asset routing)
- [ ] **Refund semantics changed** (who can refund, who receives refunds, timelock values, refund-address pinning)
- [ ] **Settlement-critical invariant changed** (e.g. non-custodial guarantee, no-admin-escape-hatch, permissionless refund)
- [x] **None of the above** — this PR cannot move, hold, or release user funds

Changed logic is API-edge validation + canonical storage/lookup of address strings only; claim/refund/timelock/hashlock state-machine code is untouched. `docs/REVIEW_RESPONSE.md` §10 documents this and was updated in this PR.

## Tests run

Tick the matches your change and paste the outcome below. Commands mirror the matrix in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] `pnpm --filter @oversync/sdk build && pnpm --filter @oversync/sdk exec tsc --noEmit`
- [x] `pnpm --filter @oversync/sdk test`
- [x] `pnpm --filter @oversync/coordinator exec tsc --noEmit && pnpm --filter @oversync/coordinator test`
- [x] `pnpm --filter @oversync/resolver exec tsc --noEmit && pnpm --filter @oversync/resolver test`
- [x] `pnpm --filter @oversync/frontend exec tsc --noEmit && pnpm --filter @oversync/frontend test`
- [x] `pnpm --filter @oversync/contracts compile && pnpm --filter @oversync/contracts exec hardhat test test/v2/HTLCEscrow.test.ts test/v2/ResolverRegistry.test.ts`
- [ ] `cd soroban && stellar contract build && cargo test --release` — not run, `soroban/` untouched
- [ ] `(cd contracts && forge test --match-path "test/foundry/*" -v)` — not run, Solidity untouched
- [x] `pnpm test:e2e` (cross-chain differential harness) — run as the `e2e` package under `pnpm test`
- [x] `node scripts/verify-addresses.mjs` — required if addresses, configs, or `env.example` change
- [x] `node scripts/check-evidence-links.mjs` — advisory; required if docs links change

Free-form outcome:

```
Full matrix via `pnpm build` (6/6 packages) + `pnpm test`, run on BOTH runtimes:

Node v22.14.0 (>= 22.5, per repo .nvmrc 24.2.0):
  packages/sdk    13 files, 208/208 passed
  coordinator     14 files, 167/167 passed (incl. all 51 node:sqlite DB tests)
  resolver         5 files,  60/60 passed
  frontend        18 files, 133/133 passed
  relayer          2 files,  21/21 passed
  contracts       21 passing (hardhat)
  e2e              2 files,  22/22 passed
  => pnpm test exit 0

Node v20.20.2 (default CI-less dev runtime, no node:sqlite):
  identical, except coordinator: 10 files passed | 4 skipped, 116 passed + 51 skipped
  (the 51 = DB-persistence suites, skipped via describe.runIf(hasNativeSqlite())
   with a "requires Node >= 22.5" message — no silent failures, exit 0)

node scripts/verify-addresses.mjs       -> 21 verified, 0 failures
node scripts/check-evidence-links.mjs   -> 12 pre-existing broken links in docs,
                                           none introduced by this PR; every link
                                           added in REVIEW_RESPONSE.md §10 resolves
```

## UI / evidence artefacts

Required if the PR changes the frontend, observability, dashboards, or any docs that claim status, metrics, or addresses. Otherwise write `n/a`.

- [ ] **Frontend visible change** → screenshot or short clip attached (swap flow, refund dialog, history banner, wallet confirm)
  — no screenshot produced from this environment; the only visible change is canonical-case address rendering (`frontend/src/components/TokenSelector.tsx`) and the corrected Sepolia USDC constant (`frontend/src/config/networks.ts`).
- [x] **Coordinator API change** → `curl` snippet + JSON response sample pasted below

Captured live from this branch's coordinator (Node 22.14, real SQLite, port 3999):

```
$ curl -s -X POST localhost:3999/api/orders/announce -H 'content-type: application/json' \
    -d '{"direction":"eth_to_xlm","hashlock":"0x9f86…a08","srcChain":"ethereum",
         "srcAddress":"0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238","srcAsset":"USDC",
         "srcAmount":"1000000","srcSafetyDeposit":"0","dstChain":"stellar",
         "dstAddress":"GDQK…7AS6","dstAsset":"USDC:GDQK…7AS6","dstAmount":"1000000"}'
HTTP 201
{"id":"800910d2…","direction":"eth_to_xlm","status":"announced",
 "src":{"chain":"ethereum","address":"0x1c7d4b196cb0c7b01d743fbc6116a902379c7238", ...}}
   ^ stored lowercase canonical, even though request used EIP-55 mixed case

$ curl -s 'localhost:3999/api/orders/history?address=0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
HTTP 200 -> 1 matching order (valid EIP-55 query)

$ curl -s 'localhost:3999/api/orders/history?address=%20%200x1c7d4b196cb0c7b01d743fbc6116a902379c7238%20'
HTTP 200 -> 1 matching order (whitespace-padded + lowercase query, trimmed + canonicalized)

$ curl -s 'localhost:3999/api/orders/history?address=0x1C7D4B196Cb0C7B01d743Fbc6116a902379C7238'
HTTP 400
{"error":"invalid_address","message":"address has an invalid EIP-55 checksum (expected 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238)"}

$ curl -s -X POST localhost:3999/api/orders/announce … "srcAddress":"0x1c7D4B196Cb0C7B01d743Fbc6116a902379C723" (39 hex digits)
HTTP 400
{"error":"order_validation_error","message":"srcAddress must be 40 hex digits after 0x (got 39)"}

$ curl -s -X POST localhost:3999/api/orders/announce … "dstAddress":"gdqk…6" (lowercase Stellar)
HTTP 400
{"error":"order_validation_error","message":"dstAddress must be a Stellar account ID (G + 55 base32 characters)"}

$ curl -s 'localhost:3999/api/orders/history?address=GDQK…7AS6'
HTTP 200 -> 1 matching order (Stellar dst side of the same bridge order)
```

- [ ] **Metrics / KPI change** → n/a
- [ ] **Status table / README change** → n/a

## Secrets, logging, and PII risk

- [x] No secrets, private keys, RPC credentials, `.env` content, wallet mnemonics, or preimages added to the repo
- [x] No new `console.*` / `logger.*` line that prints secrets, preimages, signed payloads, or PII
- [x] No new Vite/build flag that exposes devtools output in production (the `VITE_*` and `esbuild.drop` policy still holds)
- [x] **None of the above** — explain why this PR cannot be a secrets / logging risk:

Validation error bodies echo only the *public* canonical form of the public address the caller itself submitted (e.g. the expected EIP-55 checksum); no preimages, keys, or signed payloads are ever logged or returned.

## Public proof links (SCF / investor evidence)

Only required for SCF tranche PRs or investor evidence packs. Otherwise write `n/a`.

n/a

## Breaking change & rollback

- [x] **Breaking change?** Yes / No — describe caller impact, data migrations, revert safety:

  **Soft break at the API edge.** Malformed addresses (mixed-case with a broken EIP-55 checksum, wrong hex length, lowercase Stellar IDs, untrimmable garbage) are now rejected with `400` instead of being stored/queried verbatim. Callers sending all-lowercase or valid EIP-55 addresses are unaffected. **No schema change, no migration, no new dependencies.** ETH addresses are stored in lowercase canonical form and lookups canonicalize the query, so new and canonical data is always mutually reachable; the coordinator DB is documented as a rebuildable cache of on-chain state, so any pre-existing mixed-case rows (none in this pre-launch testnet deployment) can be lowercased with a one-liner or rebuilt from chain events.

- [x] **Migration or feature flag required?** Yes / No — describe the path:

  **No.** Rollback is a single `git revert` of the branch: the coordinator returns to verbatim storage/lookup (pre-PR behavior) with no data migration in either direction.

## Reviewer checklist (for the PR author to self-verify)

- [x] PR description and code comments are in English
- [x] Linked issue or milestone
- [x] No unrelated drive-by changes (reformatting, dep bumps, etc.)
- [x] Tests touch the same files as the source change
- [x] PR is reversible: a single `git revert` restores prior state

---

## Files in this branch (30: 3 created / 27 modified)

```
created
  coordinator/test/support/node-sqlite.ts      hasNativeSqlite() probe for runIf skips
  packages/sdk/src/addresses/index.ts          new canonicalization module
  packages/sdk/test/addresses.test.ts          36 tests
modified
  coordinator/src/persistence/db.ts            lazy node:sqlite load + clear Node<22.5 error
  coordinator/src/server/routes/orders.ts      announce/history validation + 400 mapping
  coordinator/src/services/order-service.ts    canonicalize on write/lookup, idempotent secret reveal
  coordinator/test/http-routes.test.ts
  coordinator/test/order-fixtures.test.ts
  coordinator/test/order-metrics.test.ts
  coordinator/test/order-service.test.ts
  coordinator/test/order-transitions.test.ts
  coordinator/test/quote-expiry.test.ts
  coordinator/test/secret-validation.test.ts
  coordinator/test/snapshot.test.ts
  e2e/evm-fixture.ts                           kill hardhat process tree (no leaked nodes)
  frontend/package.json                        pretest builds SDK dist
  frontend/src/App.test.tsx                    networks mock
  frontend/src/components/TokenSelector.tsx    canonical display
  frontend/src/config/networks.ts              Sepolia USDC = 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238
  packages/sdk/src/assets/capabilities.ts
  packages/sdk/src/assets/index.ts             strict canonical asset matching
  packages/sdk/src/deployment-evidence/index.ts  JSON import attribute for ESM
  packages/sdk/src/index.ts                    export addresses module
  packages/sdk/test/assets.test.ts
  relayer/src/index.ts
  relayer/src/utils.ts                         canonicalization + trim-tolerant validators
  relayer/test/address-utils.test.ts
  scripts/lib/testnet-asset-consistency.mjs    USDC constant
  docs/REVIEW_RESPONSE.md                      section 10
```

**Notes for reviewers**

1. In a fresh clone run `pnpm build` before `pnpm test`: the coordinator tests import the SDK's built `dist/`, and the repo's test scripts don't build it first (pre-existing quirk; CI builds before testing and is unaffected).
2. Pre-existing deploy gap (disclosed, not fixed here): `tsc` does not copy `coordinator/src/persistence/schema.sql` into `dist/`, so `node dist/index.js` with SQLite needs a copy step added to the build.

CLOSE #845 